### PR TITLE
Oppdaterte lenker til ressurser til å peke til raw.githubusercontent

### DIFF
--- a/nb-NO/scratch/egne/halloweenimasjon/halloweenimasjon.md
+++ b/nb-NO/scratch/egne/halloweenimasjon/halloweenimasjon.md
@@ -1,7 +1,7 @@
 ---
 title: Halloweenimasjon
 level: 1
-author: Torbjørn Skauli
+author: Torbjørn Skauli og Geir Arne Hjelle
 ---
 
 # Introduksjon {.intro}
@@ -401,7 +401,7 @@ tipsene nedenfor.
   språket som brukes til å lage nettsider.
 
     Last ned filen
-    <http://kodeklubben.github.io/nb-NO/scratch.1/06/projiser.html>.
+    <https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/halloweenimasjon/projiser.html>.
     Etter at du har gått til denne adressen kan du velge `Fil > lagre
     som`, eller noe som ligner, i menyen til nettleseren din. Legg
     filen et sted du finner den igjen.

--- a/nb-NO/scratch/egne/hvor_i_all_verden/hvor_i_all_verden_1.md
+++ b/nb-NO/scratch/egne/hvor_i_all_verden/hvor_i_all_verden_1.md
@@ -109,7 +109,7 @@ __Klikk på det grønne flagget.__
 
 + Vi vil først laste ned kartet fra nettet. Åpne en ny fane i
   nettleseren din, og skriv inn adressen
-  <http://kodeklubben.github.io/nb-NO/scratch_kurs.2/01/europakart.png>.
+  <https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/hvor_i_all_verden/europakart.png>.
   Dette vil åpne et bilde av et europakart. Høyreklikk på bildet, og
   velg `Lagre bildet som` eller noe som ligner. Lagre bildet et sted
   du finner det igjen.

--- a/nb-NO/scratch/egne/hvor_i_all_verden/hvor_i_all_verden_2.md
+++ b/nb-NO/scratch/egne/hvor_i_all_verden/hvor_i_all_verden_2.md
@@ -51,7 +51,7 @@ ferdige.
   av `Ny figur`.  Velg filen `europakart.png` som du lastet ned
   forrige gang. Hvis du ikke har denne lett tilgjengelig kan du laste
   den ned på nytt fra
-  <http://kodeklubben.github.io/nb-NO/scratch_kurs.2/02/europakart.png>.
+  <https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/hvor_i_all_verden/europakart.png>.
 
 + Gi denne nye kartfiguren navnet `Kart`.
 
@@ -347,7 +347,7 @@ spillet, samt legge på en tidsbegrensning og poengsum.
 + Fortsatt er ikke kartet så veldig stort. En måte å komme seg rundt
   begrensningen på figurstørrelse i Scratch er å la bakgrunnen bestå
   av flere deler. Filen
-  <http://kodeklubben.github.io/nb-NO/scratch_kurs.2/02/europakart.zip>
+  <https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/hvor_i_all_verden/europakart.zip>
   inneholder 9 kartfliser du kan prøve å pusle sammen. Du må da laste
   inn hver av dem som en egen figur. Hver av dem trenger omtrent samme
   kode som kartet vi har brukt så langt. Du må bare endre litt i `gå

--- a/nb-NO/scratch/egne/norgestur/README.md
+++ b/nb-NO/scratch/egne/norgestur/README.md
@@ -22,7 +22,7 @@ er gitt i Steg 1 av oppgaven.
 
 Alternativt, kan du gjøre kartet tilgjengelig for deltakerne på
 forhånd om dette er mulig. Kartet er tilgjengelig på
-<http://kodeklubben.github.io/nb-NO/scratch.1/04/norgeskart.png>.
+<https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/norgestur/norgeskart.png>.
 
 # Læringsmål
 

--- a/nb-NO/scratch/egne/norgestur/norgestur.md
+++ b/nb-NO/scratch/egne/norgestur/norgestur.md
@@ -24,8 +24,8 @@ raskest mulig finne steder og byer du blir bedt om å besøke.
   over det neste punktet.
 
 + Åpne en ny fane i nettleseren din og skriv inn adressen
-  <http://kodeklubben.github.io/nb-NO/scratch.1/04/norgeskart.png>. Dette
-  vil åpne et bilde av et norgeskart. Høyreklikk på bildet, og velg
+  <https://raw.githubusercontent.com/kodeklubben/oppgaver/master/nb-NO/scratch/egne/norgestur/norgeskart.png>.
+  Dette vil åpne et bilde av et norgeskart. Høyreklikk på bildet, og velg
   `Lagre bildet som` eller noe som ligner. Lagre bildet et sted du
   finner det igjen, for eksempel på Skrivebordet.
 


### PR DESCRIPTION
I noen oppgaver lenker vi til eksterne filer (f.eks. bakgrunnsbilder). Tidligere ble det lenket til kodeklubben.github.io, men dette krevde litt logistikk rundt filer som må lastes opp og navn som endrer seg. Har endret lenkene slik at de peker til raw.githubusercontent.com/kodeklubben/ i stedet. Lenkene er litt "styggere", men samtidig tryggere i det de ikke skal endre seg i fremtiden.