### PR TITLE
Fixed last codeblock++

### DIFF
--- a/nb-NO/python/tre_pa_rad_mot_datamaskinen/tre_pa_rad_mot_datamaskinen.md
+++ b/nb-NO/python/tre_pa_rad_mot_datamaskinen/tre_pa_rad_mot_datamaskinen.md
@@ -465,10 +465,7 @@ def play_move():
 c.bind("<Button-1>", click)
 
 mainloop()
-logo: ../../../assets/img/ccuk_logo.png
-author: Oversatt fra [Code Club UK](//codeclub.org.uk)
-license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
----
+```
 
 ## Utfordring {.challenge}
 


### PR DESCRIPTION
Fikset dårlig rendring av kodeblokk (la til avsluttende <code>```</code>), i tillegg til at det ser ut som at rester av en yaml-header hadde forvillet seg ned til bunnen.