### PR TITLE
Fargedirektiver på stoppklosser og egendefinerte klosser

### DIFF
--- a/src/scratch/3d_flakser/3d_flakser_2.md
+++ b/src/scratch/3d_flakser/3d_flakser_2.md
@@ -48,7 +48,7 @@ vi kaller `bakken`.
             sett y til ((20) - (y))
             hvis (berører [Flakse v])
                 si [du tapte!] i (2) sekunder
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```
@@ -184,7 +184,7 @@ ring-figuren.
     ```blocks
         hvis ((berører [Flakse v]) og ((distanse) < (1.2)))
             si [du tapte!] i (1) sekunder
-            stopp [alle v] 
+            stopp [alle v] :: control
         slutt
     ```
 

--- a/src/scratch/flaksefugl/flaksefugl.md
+++ b/src/scratch/flaksefugl/flaksefugl.md
@@ -234,14 +234,14 @@ __Klikk det grønne flagget.__
         spill lyden [screech v]
         si [Du tapte!]
         send melding [Tap v]
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 + Klikk så på `Rør`-figuren og legg til dette skriptet:
 
     ```blocks
         når jeg mottar [Tap v]
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 ## Test prosjektet {.flag}
@@ -361,7 +361,7 @@ Når spilleren taper vil vi at Flakse faller ned og ut av skjermen.
         slutt
         skjul
         send melding [Tap v]
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 + Du må også legge til en `vis`{.blocklooks}-kloss samt sette Flakses
@@ -388,7 +388,7 @@ __Klikk det grønne flagget.__
         hvis <(poeng) > (Rekord)>
             sett [Rekord v] til (poeng)
         slutt
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 ## Nettvariabler {.protip}

--- a/src/scratch/frantic_felix/frantic_felix.md
+++ b/src/scratch/frantic_felix/frantic_felix.md
@@ -546,7 +546,7 @@ Og her er redningskapselen, som håndterer all nivå-endringen:
 			    hvis <[nåværende nivå v] = <lengden av [nøkler per brett v]>
 				    si [Du vant!!]
                     send melding [seier v]
-                    stopp [alle v]
+                    stopp [alle v] :: control
                 ellers
 				    endre [nåværende nivå v] med (1)
                     send melding [start brett v]

--- a/src/scratch/hvor_i_all_verden/hvor_i_all_verden_2.md
+++ b/src/scratch/hvor_i_all_verden/hvor_i_all_verden_2.md
@@ -292,13 +292,11 @@ eller lage egne klosser som man gjør i Scratch.
   vi bruker den nye funksjonen. For eksempel
 
     ```blocks
-        definer Reis til (sted) (x) (y)
-
         når jeg mottar [Nytt spill v]
         vis
-        Reis til [London] (-135) (-30)
-        Reis til [Oslo] (-30) (75)
-        Reis til [Barcelona] (-135) (-175)
+        Reis til [London] (-135) (-30) :: custom
+        Reis til [Oslo] (-30) (75) :: custom
+        Reis til [Barcelona] (-135) (-175) :: custom
     ```
 
 + Om du prøver spillet nå vil du kanskje oppdage et lite

--- a/src/scratch/hvor_i_all_verden/hvor_i_all_verden_3.md
+++ b/src/scratch/hvor_i_all_verden/hvor_i_all_verden_3.md
@@ -129,11 +129,9 @@ sier hvor stedet ligger. En måte å gjøre dette på er å bruke tre lister.
   lagde forrige gang.
 
     ```blocks
-        definer Reis til (sted) (x) (y)
-
         når jeg mottar [Nytt sted v]
         sett [sted v] til (tilfeldig tall fra (1) til (lengden av [steder v]))
-        Reis til (element (sted) av [steder v]) (element (sted) av [stederX v]) (element (sted) av [stederY v])
+        Reis til (element (sted) av [steder v]) (element (sted) av [stederX v]) (element (sted) av [stederY v]) :: custom
     ```
 
 + Prøv å kjør spillet flere ganger. Virker det som om reisemålet blir
@@ -242,7 +240,7 @@ programflyten omtrent som dette:
     ```blocks
         når jeg mottar [Spill slutt v]
         skjul
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
     Med `stopp`{.blockcontrol}-klossen passer vi på at alle skriptene

--- a/src/scratch/labyrint/labyrint.md
+++ b/src/scratch/labyrint/labyrint.md
@@ -373,7 +373,7 @@ Dette blir veldig likt hvordan `Skatt` merket at den ble funnet.
         for alltid
             hvis (berører [Utforsker v]?)
                 si [Tok deg!] i (1) sekunder
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```

--- a/src/scratch/lydmaskin/lydmaskin-opptaker.md
+++ b/src/scratch/lydmaskin/lydmaskin-opptaker.md
@@ -73,7 +73,7 @@ Trykk på opptaksknappen. Hva skjer når du spiller på instrumentene?
                 send melding (element (index) av [instrument v])
                 endre [index v] med (1)
                 hvis <(index) > (lengden av [timing v])>
-                    stopp [dette skriptet]
+                    stopp [dette skriptet] :: control
                 slutt
             slutt
         slutt

--- a/src/scratch/norgestur/norgestur.md
+++ b/src/scratch/norgestur/norgestur.md
@@ -493,7 +493,7 @@ __Klikk på det grønne flagget.__
 
     ```blocks
         når jeg mottar [Avslutt v]
-        stopp [alle v]
+        stopp [alle v] :: control
     ```
 
 ## Test prosjektet {.flag}

--- a/src/scratch/soloball/soloball.md
+++ b/src/scratch/soloball/soloball.md
@@ -249,7 +249,7 @@ truffet nettet. Det skal vi gjøre nå.
                 pek i retning ((180) + (retning))
             slutt
             hvis (berører fargen [#ff0000] ?)
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```
@@ -322,7 +322,7 @@ Vi kan forenkle dette til
                 pek i retning (((180) - (retning)) + ((2) * ([retning v] av [Katt v])))
             slutt
             hvis (berører fargen [#ff0000] ?)
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```
@@ -384,7 +384,7 @@ starter. Deretter skal vi få ett poeng hver gang vi returnerer ballen.
                 endre [Poeng v] med (1)
             slutt
             hvis (berører fargen [#ff0000] ?)
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```
@@ -433,7 +433,7 @@ selv!
                 endre [Hastighet v] med (0.1)
             slutt
             hvis (berører fargen [#ff0000] ?)
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```
@@ -479,7 +479,7 @@ sist snudde.
                 sett [Flytt v] til (0)
             slutt
             hvis (berører fargen [#ff0000] ?)
-                stopp [alle v]
+                stopp [alle v] :: control
             slutt
         slutt
     ```

--- a/src/scratch/spokelsesjakten/spokelsesjakten.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten.md
@@ -210,7 +210,7 @@ __Klikk på det grønne flagget.__
             vent (1) sekunder
             endre [Tid v] med (-1)
         slutt
-        stopp [alle v]
+        stopp [alle v] :: control
     ```
 
 ## Test prosjektet {.flag}

--- a/src/scratch/straffespark/straffespark.md
+++ b/src/scratch/straffespark/straffespark.md
@@ -229,7 +229,7 @@ reagere på ting som skjer.
 
     ```blocks
         når jeg mottar [Redning v]
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 ## Test prosjektet {.flag}
@@ -277,7 +277,7 @@ merket `x` og `y`. Disse viser koordinatene til musepekeren.
 
     ```blocks
         når jeg mottar [Mål v]
-        stopp [andre skript i figuren v]
+        stopp [andre skript i figuren v] :: control
     ```
 
 + Vi kan også la `Leo` juble litt når han scorer mål. Klikk på
@@ -419,7 +419,7 @@ mål eller `Keeper` klarer å redde 10 ganger. Dette er litt omfattende.
             send melding [Nytt spark v]
         ellers
             bytt bakgrunn til [Seier v]
-            stopp [alle v]
+            stopp [alle v] :: control
         slutt
     ```
 
@@ -433,7 +433,7 @@ mål eller `Keeper` klarer å redde 10 ganger. Dette er litt omfattende.
             send melding [Nytt spark v]
         ellers
             bytt bakgrunn til [Tap v]
-            stopp [alle v]
+            stopp [alle v] :: control
         slutt
     ```
 


### PR DESCRIPTION
Det finnes stopp-klosser i to kategorier: Kontroll og tilleggsfunksjoner. Legger derfor til fargedirektiver (eg. kategoridirektiver) slik at disse rendres korrekt.

Egnedefinerte klosser trenger også fargedirektiver når de ikke vises i samme kodeblokk som der de ble definert.