### PR TITLE
Legg til oversetter på Code Club UK oppgavene

### DIFF
--- a/src/python/hangman/hangman.md
+++ b/src/python/hangman/hangman.md
@@ -3,6 +3,7 @@ title: Hangman
 level: 3
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Geir Arne Hjelle
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/hemmelige_koder/hemmelige_koder.md
+++ b/src/python/hemmelige_koder/hemmelige_koder.md
@@ -3,6 +3,7 @@ title: Hemmelige koder
 level: 2
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Bjørn Einar Bjartnes
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/skilpadder/skilpadder.md
+++ b/src/python/skilpadder/skilpadder.md
@@ -3,6 +3,7 @@ title: Skilpadder
 level: 1
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Bjørn Einar Bjartnes
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/skilpadder_hele_veien/skilpadder_hele_veien.md
+++ b/src/python/skilpadder_hele_veien/skilpadder_hele_veien.md
@@ -3,6 +3,7 @@ title: Skilpadder hele veien ned
 level: 3
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Bjørn Einar Bjartnes
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/skilpaddeskolen/skilpaddeskolen.md
+++ b/src/python/skilpaddeskolen/skilpaddeskolen.md
@@ -1,8 +1,9 @@
 ---
 title: Skilpaddeskolen
-level: 1
+level: 2
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Bjørn Einar Bjartnes
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/tre_pa_rad/tre_pa_rad.md
+++ b/src/python/tre_pa_rad/tre_pa_rad.md
@@ -3,6 +3,7 @@ title: Tre på rad
 level: 3
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Geir Arne Hjelle
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/python/tre_pa_rad_mot_datamaskinen/tre_pa_rad_mot_datamaskinen.md
+++ b/src/python/tre_pa_rad_mot_datamaskinen/tre_pa_rad_mot_datamaskinen.md
@@ -1,8 +1,9 @@
 ---
 title: Tre på rad mot datamaskinen
-level: 4
+level: 3
 logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Geir Arne Hjelle
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/enarmet_banditt/enarmet_banditt.md
+++ b/src/scratch/enarmet_banditt/enarmet_banditt.md
@@ -1,7 +1,9 @@
 ---
 title: Enarmet banditt
 level: 2
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Gudbrand Tandberg og Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/felix_og_herbert/felix_og_herbert.md
+++ b/src/scratch/felix_og_herbert/felix_og_herbert.md
@@ -1,7 +1,9 @@
 ---
 title: Felix og Herbert
 level: 1
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Gudbrand Tandberg
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/flaksefugl/flaksefugl.md
+++ b/src/scratch/flaksefugl/flaksefugl.md
@@ -1,7 +1,9 @@
 ---
 title: Flaksefugl
+logo: ../../assets/img/ccuk_logo.png
 level: 2
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Helge Astad
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/frantic_felix/frantic_felix-avspilling.md
+++ b/src/scratch/frantic_felix/frantic_felix-avspilling.md
@@ -1,7 +1,9 @@
 ---
 title: Frantic Felix - Avspilling
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/frantic_felix/frantic_felix-opptak.md
+++ b/src/scratch/frantic_felix/frantic_felix-opptak.md
@@ -1,7 +1,9 @@
 ---
 title: Frantic Felix - Opptak
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/frantic_felix/frantic_felix.md
+++ b/src/scratch/frantic_felix/frantic_felix.md
@@ -2,7 +2,9 @@
 title: Frantic Felix
 level: 4
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/fyrverkeri/fyrverkeri.md
+++ b/src/scratch/fyrverkeri/fyrverkeri.md
@@ -1,7 +1,9 @@
 ---
 title: Fyrverkeri
 level: 2
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Kaisa Korsak
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/hva_er_det/hva_er_det.md
+++ b/src/scratch/hva_er_det/hva_er_det.md
@@ -1,7 +1,9 @@
 ---
 title: Hva er det?
 level: 3
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/jafsefisk/jafsefisk.md
+++ b/src/scratch/jafsefisk/jafsefisk.md
@@ -1,7 +1,9 @@
 ---
 title: JafseFisk
 level: 2
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/lag_ditt_eget_monster.md
+++ b/src/scratch/lag_ditt_eget_monster/lag_ditt_eget_monster.md
@@ -2,7 +2,9 @@
 title: Lag ditt eget monster
 level: 4
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-armer.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-armer.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Hengslede armer
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-ben.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-ben.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Ben
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-bevegelse.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-bevegelse.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Bevegelse
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-hjul.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-hjul.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Hjul
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-munn.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-munn.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Pratende Munn
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-oyne.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-oyne.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Øyne
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_monster/monster-tentakler.md
+++ b/src/scratch/lag_ditt_eget_monster/monster-tentakler.md
@@ -1,7 +1,9 @@
 ---
 title: Monster - Tentakler
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lag_ditt_eget_spill/lag_ditt_eget_spill.md
+++ b/src/scratch/lag_ditt_eget_spill/lag_ditt_eget_spill.md
@@ -1,7 +1,9 @@
 ---
 title: Lag ditt eget spill
 level: 4
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lydmaskin/lydmaskin-lyder.md
+++ b/src/scratch/lydmaskin/lydmaskin-lyder.md
@@ -1,7 +1,9 @@
 ---
 title: Lydmaskin - Lyder
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lydmaskin/lydmaskin-opptaker.md
+++ b/src/scratch/lydmaskin/lydmaskin-opptaker.md
@@ -1,7 +1,9 @@
 ---
 title: Lydmaskin - Opptaker
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lydmaskin/lydmaskin-piano.md
+++ b/src/scratch/lydmaskin/lydmaskin-piano.md
@@ -1,7 +1,9 @@
 ---
 title: Lydmaskin - Piano
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lydmaskin/lydmaskin-tromme.md
+++ b/src/scratch/lydmaskin/lydmaskin-tromme.md
@@ -1,7 +1,9 @@
 ---
 title: Lydmaskin - Tromme
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/lydmaskin/lydmaskin.md
+++ b/src/scratch/lydmaskin/lydmaskin.md
@@ -2,7 +2,9 @@
 title: Lydmaskin
 level: 4
 indexed: false
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Lars-Erik Wollan
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/orkenlop/orkenlop.md
+++ b/src/scratch/orkenlop/orkenlop.md
@@ -1,7 +1,9 @@
 ---
 title: Ørkenløp
 level: 2
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/spokelsesjakten/spokelsesjakten.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten.md
@@ -1,7 +1,9 @@
 ---
 title: Spøkelsesjakten
 level: 1
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Gudbrand Tandberg
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 

--- a/src/scratch/tegneprogram/tegneprogram.md
+++ b/src/scratch/tegneprogram/tegneprogram.md
@@ -1,7 +1,9 @@
 ---
 title: Tegneprogram
 level: 3
+logo: ../../assets/img/ccuk_logo.png
 author: Oversatt fra [Code Club UK](//codeclub.org.uk)
+translator: Helge Astad og Anne-Marit Gravem
 license: "[Code Club World Limited Terms of Service](https://github.com/CodeClub/scratch-curriculum/blob/master/LICENSE.md)"
 ---
 


### PR DESCRIPTION
Lagt til translator i yaml-headeren på python og scratch-oppgavene.

Har også lagt til logo i yaml-headeren på scratch-oppgavene, men dette hadde ingen effekt lokalt. Fortsatt vises bare kodeklubben-logoen.