### PR TITLE
Stabil travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "stable"
-install: ./setup
+install: ./travis-install.sh
 script: ./gulp dist && ./gulp links
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ notifications:
 addons:
   apt_packages:
     - pandoc
+cache:
+  directories:
+    - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "stable"
 install: ./setup
 script: ./gulp dist && ./gulp links
 notifications:

--- a/travis-install.sh
+++ b/travis-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+git submodule init && \
+git submodule update --depth 1 && \
+cd codeclub_lesson_builder && \
+sed -i "/^.*\"browser-sync\".*$/d" package.json && \
+npm install


### PR DESCRIPTION
Noen ganger henger travis grunnet at `done()` aldri kalles (når siste lenke feiler). Dette er fikset i siste versjon av [node-spider](github.com/flesler/node-spider).

PR inkluderer også litt endringer i travis konfigurasjon:
- bruk cache på `node_modules`
- kjør testen med siste versjon av node