### PR TITLE
Lenke til Processing.org sin kodetime-oppgave

### DIFF
--- a/src/processing/ekstern_processing_org/hello_processing.md
+++ b/src/processing/ekstern_processing_org/hello_processing.md
@@ -1,0 +1,5 @@
+---
+title: Hello Processing! (Engelsk)
+level: 1
+external: http://hello.processing.org/
+---


### PR DESCRIPTION
Som foreslått og raskt diskutert på Facebook.

Vi har på andre rene videokurs skrevet Video i tittelen. Burde vi ha det her også? Selv om det ikke er et rent videokurs?

Jeg tok også med en kort kommentar om at det er på engelsk. Er dette en grei måte å gjøre dette på?