### PR TITLE
Fikser at node dreper skriptet, og bytter til push pop istedenfor cd.

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,7 +1,7 @@
 @echo off
 git submodule init
 git submodule update --depth 1
-cd codeclub_lesson_builder
-npm install
-cd ..
+pushd codeclub_lesson_builder
+call npm install
+popd
 pause


### PR DESCRIPTION
Node bruker .cmd-filer som krever at man bruker call når man kjører dem fra batch-skript.

I skript bør man også bruke pushd og popd for å bevege seg mellom mapper.