### PR TITLE
Fix for Firefox

### DIFF
--- a/src/scratch/kart/kart.js
+++ b/src/scratch/kart/kart.js
@@ -18,7 +18,9 @@ document.getElementById("last_ned_som_bilde").addEventListener("click", function
   leafletImage(scratchMap, downloadMapAsImage);});
 
 function downloadMapAsImage(err, canvas) {
-  var a = document.createElement("a");
+  var a = document.createElement('a');
+  document.body.appendChild(a);
+  a.setAttribute('type', 'hidden');
   var img = document.createElement('img');
   var dimensions = scratchMap.getSize();
   img.width = dimensions.x;


### PR DESCRIPTION
Nå skal denne fungere også i Firefox. Har ikke IE eller Safari så har ikke fått testet dem skikkelig.

Tidligere har det ikke skjedd noe når man har trykket `Last ned`-knappen i Firefox og IE (funker fint i Chrome, har ikke fått testet safari).