### PR TITLE
web partikkel: fiks racing feil med setInterval/onload

### DIFF
--- a/src/web/partikkel_2/partikkel_2.md
+++ b/src/web/partikkel_2/partikkel_2.md
@@ -1,12 +1,12 @@
---- 
+---
 title: "JS: Partikkel-fest"
 level: 3
 ---
 
 # Introduksjon {.intro}
-Denne oppgaven bygger på koden du skrev i oppgaven [Partikkel-animasjon](../partikkel_animasjon/partikkel_animasjon.html). Så dersom du ikke har gjort den, så anbefaler vi å gjøre [Partikkel-animasjon](../partikkel_animasjon/partikkel_animasjon.html) før du fortsetter på denne oppgaven. 
+Denne oppgaven bygger på koden du skrev i oppgaven [Partikkel-animasjon](../partikkel_animasjon/partikkel_animasjon.html). Så dersom du ikke har gjort den, så anbefaler vi å gjøre [Partikkel-animasjon](../partikkel_animasjon/partikkel_animasjon.html) før du fortsetter på denne oppgaven.
 
-Her skal vi videreutvikle `partikkel`-animasjonen vår slik at den ser slik ut: 
+Her skal vi videreutvikle `partikkel`-animasjonen vår slik at den ser slik ut:
 
 <canvas id="canvas" width="500" height="500"></canvas>
 
@@ -15,23 +15,17 @@ Her skal vi videreutvikle `partikkel`-animasjonen vår slik at den ser slik ut:
 
         var canvas, ctx;
         var partikkelListe = [];
-        
-        var drawInterval = setInterval(function(){draw()}, 30);
-
-
-        
-        
 
         window.onload = function(){
             canvas = document.getElementById("canvas");
             ctx = canvas.getContext("2d");
-            drawInterval;
+            setInterval(draw, 30);
         };
 
 
         //Tegner og skyter particle opp
         function draw(){
-            
+
             var particle = {
                 x: 250,
                 y: 250,
@@ -40,36 +34,36 @@ Her skal vi videreutvikle `partikkel`-animasjonen vår slik at den ser slik ut:
                 size: 10
 
             };
-            
+
             partikkelListe.push(particle);
-            
+
             ctx.clearRect(0,0,500,500);
 
-            
+
             for (var i=0; i<partikkelListe.length; i++) {
                 particle = partikkelListe[i];
-            
 
-                
+
+
                 ctx.fillStyle = 'red';
                 ctx.fillRect(particle.x, particle.y,particle.size,particle.size);;
-            
+
                 particle.x = particle.x + particle.xSpeed;
                 particle.y = particle.y + particle.ySpeed;
-            
+
                 particle.size = particle.size * 0.96;
             }
 
         }
 </script>
 
-Merk at i denne oppgaven vil du kun få beskrevet hva du skal gjøre med et par hint. Du vil ikke få presentert den ferdige koden. 
+Merk at i denne oppgaven vil du kun få beskrevet hva du skal gjøre med et par hint. Du vil ikke få presentert den ferdige koden.
 
-# Steg 1: Hva må gjøres? {.activity} 
-I denne oppgaven får du kun små eksempler på kode for å hjelpe deg til å komme frem til resultatet. Derfor skal vi gå gjennom tankemåten til å lage animasjonen over ved å presentere en liste over ting som må gjøres: 
+# Steg 1: Hva må gjøres? {.activity}
+I denne oppgaven får du kun små eksempler på kode for å hjelpe deg til å komme frem til resultatet. Derfor skal vi gå gjennom tankemåten til å lage animasjonen over ved å presentere en liste over ting som må gjøres:
 
 La oss studere animasjonen og analysere hva den inneholder:
-+ Et partikkel i midten av skjermen som alltid er der. Hva kan være grunnen til det? 
++ Et partikkel i midten av skjermen som alltid er der. Hva kan være grunnen til det?
 + Partiklene som går ut fra midten og blir mindre og mindre jo lengre ut de går
 + Hastigheten til hvert partikkel varierer
 + Retningen varierer, men et partikkel reiser i en rett linje
@@ -86,7 +80,7 @@ xSpeed: Math.floor(Math.random()*20 - Math.random()*20));
 Dette vil gjøre at du får et positivt eller negativt tall med varierende hastighet fra -20 til 20 i `x`-retning. Gjør det samme for `y`-retningen for å få partiklene til å bevege seg overalt på skjermen.
 ##
 + For å få dem til å følge en rett linje bruker vi bare endringer i `x`- og `y`-retning fra forrige oppgave: `particle.x = particle.x + particle.xSpeed;`.
-+ Siden det er mange som blir laget på engang må vi for hver gang `draw()` blir kalt, legge et nytt partikkel i en `liste` og bruke en `for`-løkke til å endre hvert partikkel sine attributter og gjenta dette for alle elementene i listen. 
++ Siden det er mange som blir laget på engang må vi for hver gang `draw()` blir kalt, legge et nytt partikkel i en `liste` og bruke en `for`-løkke til å endre hvert partikkel sine attributter og gjenta dette for alle elementene i listen.
 
 
 #### Prøv selv først! Dersom du ikke får det til kan du benytte deg av hintene under.
@@ -97,15 +91,15 @@ Dette vil gjøre at du får et positivt eller negativt tall med varierende hasti
 ```js
 for(var i = 0; i<listeNavn.length; i++){
     //kode
-    element = listeNavn[i] // element blir nå det i-te elementet i listen, "i" blir her et tall fra 0 til lengden av listen. 
+    element = listeNavn[i] // element blir nå det i-te elementet i listen, "i" blir her et tall fra 0 til lengden av listen.
 }
 ```
 ##
 
 ## Oppbygning av koden {.tip}
-For at du skal kunne bygge opp koden slik at partiklene oppfører seg som den gjør i animasjonen må vi tenke over hvor vi putter koden vår. 
+For at du skal kunne bygge opp koden slik at partiklene oppfører seg som den gjør i animasjonen må vi tenke over hvor vi putter koden vår.
 + All endring på partikkel-objektet bør skje i `for`-løkken. På denne måten vil endringene skje gradvis som gjør at animasjonen blir finere.
 + Når man bør legge elementer i `partikkel`-lista bør du eksperimentere litt med.
 + Du bør også eksperimentere litt med når du bruker `clearRect()`, klarer du å se hva som er forskjellen på om du legger den i eller utenfor `for`-løkken?
 ##
- 
+

--- a/src/web/partikkel_animasjon/partikkel_animasjon.md
+++ b/src/web/partikkel_animasjon/partikkel_animasjon.md
@@ -15,8 +15,6 @@ Denne oppgaven er den første i en liten serie av andre `partikkel`-oppgaver, de
 <script>
 
         var canvas, ctx;
-        var drawInterval = setInterval(function(){draw()}, 30);
-
 
         var particle = {
             x: 0,
@@ -30,7 +28,7 @@ Denne oppgaven er den første i en liten serie av andre `partikkel`-oppgaver, de
         window.onload = function() {
             canvas = document.getElementById("canvas");
             ctx = canvas.getContext("2d");
-            drawInterval;
+            setInterval(draw, 30);
         };
 
 
@@ -47,7 +45,6 @@ Denne oppgaven er den første i en liten serie av andre `partikkel`-oppgaver, de
             if(particle.x === 300 && particle.y === 300){
                 particle.x = 0;
                 particle.y = 0;
-                drawInterval;
             }
         }
 
@@ -263,17 +260,17 @@ objekt.attributt1 = objekt.attributt1 + objekt.attributt2;
 
 For at vi skal få en animasjon så må vi kjører `draw` flere ganger enn bare 1, derfor må vi bruke `setInterval` for å gjenta `draw`.
 
-+ Lag en ny variabel som heter `drawInterval` og ser slik ut:
++ Kjør funksjonen draw hvert 30 millisekund:
 ```js
-var drawInterval = setInterval(function() { draw(); }, 30);
+setInterval(draw, 30);
 ```
 
 ## Forklaring: setInterval {.tip}
-+ `setInterval` lager en funksjon som skal kjøre hvert X millisekund
-+ `setInterval(function() { draw(); }, 30);` kjører funksjonen `draw()` hvert 30 millisekund. NB! 1000 millisekunder er ett sekund
++ `setInterval` kjører en funksjon hvert X millisekund.
++ Altså betyr `setInterval(draw, 30);` at funksjonen `draw()` kjøres hvert 30 millisekund. NB! 1000 millisekunder er ett sekund.
 ##
 
-+ Fjern `draw()`, vi trenger ikke erstatte den med `drawInterval` fordi denne gjøres automatisk når variabelen blir laget
++ Fjern `draw()`, vi trenger ikke den lenger, ettersom `setInterval` vil kjøre `draw` for oss.
 + Lagre og kjør siden vi har laget til nå!
 
 Som du ser så lager den en lang diagonal stripe. Som du kanskje har skjønt må vi finne en måte vi kan fjerne den forrige vi tegnet slik at vi skaper en illusjon om at den flytter på seg og ikke bare lager mange etter hverandre.
@@ -312,7 +309,6 @@ Ekssempel på ferdig kode til oppgaven:
     <script>
 
         var canvas, ctx;
-        var drawInterval = setInterval(function() { draw(); }, 30);
 
 
         var particle = {
@@ -327,6 +323,7 @@ Ekssempel på ferdig kode til oppgaven:
         window.onload = function() {
             canvas = document.getElementById("canvas");
             ctx = canvas.getContext("2d");
+            setInterval(draw, 30);
         };
 
 

--- a/src/web/partikkel_gravitasjon/partikkel_gravitasjon.md
+++ b/src/web/partikkel_gravitasjon/partikkel_gravitasjon.md
@@ -13,9 +13,6 @@ Oppgaven her går ut på å legge til gravitasjon på `Partikkel`-objektet. Du v
 
         var canvas, ctx;
 
-        var drawInterval = setInterval(function(){draw()}, 30);
-
-
         var particle = {
             x: 125,
             y: 0,
@@ -28,6 +25,7 @@ Oppgaven her går ut på å legge til gravitasjon på `Partikkel`-objektet. Du v
         window.onload = function() {
             canvas = document.getElementById("canvas");
             ctx = canvas.getContext("2d");
+            setInterval(draw, 30);
         };
 
 


### PR DESCRIPTION
`setInterval` kan i noen tilfeller kjøre `draw` _før_ `onload` har kjørt. Dette feiler, og akkurat nå feiler dette PDF-bygging (fiks på vei). Rydder likevel opp i denne bugen og endrer litt i teksten til oppgaven.