### PR TITLE
Fast deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,13 @@ notifications:
 cache:
   directories:
     - node_modules
+    - travis_phantomjs
+
+before_install:
+  # Upgrade PhantomJS to v2.1.1.
+  - "export PHANTOMJS_VERSION=2.1.1"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin:$PATH"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then wget https://github.com/Medium/phantomjs/releases/download/v$PHANTOMJS_VERSION/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != $PHANTOMJS_VERSION ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,16 +5,6 @@ BUILDER="$DIR/codeclub_lesson_builder"
 REPLACE="Merge pull request "
 REPLACE_WITH="kodeklubben/oppgaver"
 
-echo "cleaning dist"
-# Set CWD to the location of this file
-cd $DIR/dist && \
-if [ -e README.md ]
-then
-    find * ! -name README.md -delete
-else
-    rm -r *
-fi
-
 echo "pulling changes"
 # do not pull changes while in dir
 cd $DIR/.. && \


### PR DESCRIPTION
Raskere deploy ved å ikke bygge filer som ikke har endret seg.

Indekser vil alltid bygges, men ikke oppgaver som ikke har blitt endret og deres PDF.

Commit blir også ryddigere på https://github.com/kodeklubben/kodeklubben.github.io