### PR TITLE
Fix missing trailing `` after code block

### DIFF
--- a/src/elm/10_fraktaler/10_fraktaler.md
+++ b/src/elm/10_fraktaler/10_fraktaler.md
@@ -243,7 +243,7 @@ Vi kan binde flere navn som kan være avhengig av hverandre:
 ```elm
 describeHalfAge yearNow yearBorn =
   let age = yearNow - yearBorn
-      halfAge / 2
+      halfAge = age / 2
   in "Half the age is " ++ (toString halfAge)
 ```
 

--- a/src/elm/10_fraktaler/10_fraktaler.md
+++ b/src/elm/10_fraktaler/10_fraktaler.md
@@ -275,7 +275,7 @@ Du skal kunne bruke den slik:
 <function> : Utils.Square -> Utils.Square
 > centerSquare start
 { color = "blue", width = 9, corner = { x = 9, y = 9 } } : Utils.Square
-`
+```
 
 ... hva må x-verdien være om det nye kvadratet skal være i sentrum av det forrige?
 


### PR DESCRIPTION
Oppgaven mangler ```` etter en kodeblokk, som brekker mye av layouten. Fiks!