### PR TITLE
Legg til navnelisteoppgaven samt lenke til dataverktøyet

### DIFF
--- a/src/scratch/data_navn/data_navn.md
+++ b/src/scratch/data_navn/data_navn.md
@@ -2,7 +2,6 @@
 title: "Bruk data: Jente- og guttenavn"
 level: 2
 author: Geir Arne Hjelle
-indexed: false
 language: nb
 ---
 
@@ -148,8 +147,7 @@ __Klikk på koden din.__
 ## Prøv selv {.try}
 
 + Dette er et veldig enkelt eksempel på hva man kan gjøre med navnelistene (og
-  det har noen problemer: for eksempel må vi skrive inn navnet med stor
-  forbokstav ellers finner ikke katten det. Den finner heller ikke dobbeltnavn
+  det har noen problemer: for eksempel finner ikke katten dobbeltnavn
   som `Geir Arne`). Har du noen ideer til hvordan du kan bruke navnelistene på
   en enda mer spennende måte?
 

--- a/src/scratch/index.md
+++ b/src/scratch/index.md
@@ -30,6 +30,7 @@ igang med å lage dine egne spill.
 
 - Vi har en egen guide for veiledere og lærere: [Kom i gang med Scratch](veiledninger/kom_i_gang_med_scratch.html).
 - Last ned kart som passer som bakgrunner i Scratch: [Last ned Scratchkart](kart/kart.html).
+- Gjør om regneark og datafiler til Scratchprosjekter: [Bruk data i Scratch](data/data.html).
 - Du finner diplomer og annet grafisk materiell på [kidsakoder.no/ressurser](http://www.kidsakoder.no/ressurser).
 
 ## Videoer


### PR DESCRIPTION
Lenken til dataverktøyet var tilgjengelig tidligere, men var visst bare sjekket rett inn på kodeklubben.github.io-repoet og ble borte når byggeren virket igjen.

Navnelisteoppgaven har vært tilgjengelig siden i høst, men ikke lenket opp.

+ http://oppgaver.kidsakoder.no/scratch/data/data.html
+ http://oppgaver.kidsakoder.no/scratch/data_navn/data_navn.html

Se #294 og #295 for opprinnelig PR