### PR TITLE
Fiks feil i museoppgave

### DIFF
--- a/src/elm/08_mus/08_mus.md
+++ b/src/elm/08_mus/08_mus.md
@@ -133,10 +133,10 @@ update msg model =
 
 
 subscriptions model =
-  Sub.batch [ Mouse.moves DragAt, Mouse.ups DragEnd ]
+  Sub.batch [ ]
 ```
 
-# Steg 3: koble på musen {.activity}
+# Steg 3: Koble på musen {.activity}
 
 Vi kobler på mus:
 


### PR DESCRIPTION
Fjernet referanser til hendelsene DragAt og DragEnd, som ikke finnes.