### PR TITLE
electronics i filtertags

### DIFF
--- a/src/filtertags.md
+++ b/src/filtertags.md
@@ -2,7 +2,7 @@
 tags:
  topic: #Logical AND
     - app #Tasks for making apps to mobiles and tablets such as appinventor and swift
-    - electronic #Includes external devices such as Microbit Arduino Raspberry pi lego mindstorms.
+    - electronics #Includes external devices such as Microbit Arduino Raspberry pi lego mindstorms.
     - step_based #Interactive web-based courses that guides you through small concepts/tasks one step at the time. Such as code.org sessions by Khan Academy and Codecademy.
     - block_based #Programming-language based on Blockly
     - text_based #Programming-language based on text


### PR DESCRIPTION
Endret fra electronic til electronics. Ingen oppgaver er tagget med dette enda, så da slapp jeg å endre noe der.

Gjerne se over indenting også. Jeg måtte endre dette tidligere for at det ikke skulle feile i codeclub-veiwer. Men jeg er ikke så god i YAML...