### PR TITLE
Bytter ut {.try} med {.challenge}

### DIFF
--- a/src/appinventor/KlaskEnMuldvarp/klaskenmuldvarp.md
+++ b/src/appinventor/KlaskEnMuldvarp/klaskenmuldvarp.md
@@ -199,6 +199,6 @@ Hvordan kan du lage spillet enda bedre?
 
 Kan du gjøre spillet vanskeligere?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 Prøv å sette timeren til en lavere verdi. Hva skjer?

--- a/src/computercraft/bli_kjent_med_datamaskinen/bli_kjent_med_datamaskinen.md
+++ b/src/computercraft/bli_kjent_med_datamaskinen/bli_kjent_med_datamaskinen.md
@@ -94,7 +94,7 @@ vil se at `heiverden` er på listen over programmer.
 - [ ] For å kjøre programmet vi har laget, skriver vi `heiverden` og
 trykker enter.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Klarer du å endre på programmet slik at det for eksempel sier hei til
 deg, eller kanskje til de som sitter ved siden av deg?
@@ -287,7 +287,7 @@ vil vi endre verdien av variabelen etterhvert som svarer riktig.
   print('Du klarte ' .. ant_riktig .. ' av ' .. ant_stykker)
   ```
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Kan du endre programmet slik at det spør om andre typer mattestykker?
 For eksempel plusstykker, minusstykker eller delestykker?
@@ -412,7 +412,7 @@ Gratulerer, du har nå lært ganske mye om hvordan man programmerer
 datamaskiner med ComputerCraft i Minecraft! Prøv gjerne å forandre
 noen av programmene vi har laget. Kan du lage dem enda bedre?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Datamaskinene kan sende ut *redstone*-energi i alle retninger. Prøv å
 koble en __Trap door__ til høyre side av datamaskinen ved hjelp av

--- a/src/computercraft/bygg_et_hus/bygg_et_hus.md
+++ b/src/computercraft/bygg_et_hus/bygg_et_hus.md
@@ -45,7 +45,7 @@ kan bruke `for`-løkker for å gjenta ting.
 
   Kjør programmet. Bygger roboten en liten vegg av klosser?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Jobb videre med `bygghus`-programmet, og se om du klarer å utvide det
 slik at roboten bygger et enkelt hus med fire vegger og tak. Bruk litt
@@ -190,7 +190,7 @@ etterhvert som du skriver det inn.
   ikke variabler ha navn som inneholder de norske bokstavene æ, ø og
   å.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Prøv å endre verdiene av variablene `hoyde` og `lengde`. Gjør roboten
 som du ber den om?
@@ -263,7 +263,7 @@ kan bruke på samme måte som de innebygde kommandoene (som for eksempel
   byggVegg(3, 5)                                -- endret linje
   ```
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Endre tallene `3` og `5` i den siste linjen. Bygger roboten vegger av
 forskjellig størrelse?
@@ -431,7 +431,7 @@ vil den bare bruke en av dem. Ved hjelp av funksjonene
 
   ![](flerefarger.png)
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Nå som roboten bruker flere slotter kan du eksperimentere med å legge
 forskjellig materiale i de forskjellige slottene. På den måten kan du

--- a/src/computercraft/fjernstyr_en_robot/fjernstyr_en_robot.md
+++ b/src/computercraft/fjernstyr_en_robot/fjernstyr_en_robot.md
@@ -215,7 +215,7 @@ lang! La oss programmere dette.
 - [ ] Hva gjør unpack? Hvordan kan vi bruke `shell.run()` til å gå frem *uten*
   `unpack()`?
 
-## Nøtt {.try}
+## Nøtt {.challenge}
 
 * Åpne et nytt program: `edit many.lua` (Du kan bruke en annen editor hvis du
   vil)

--- a/src/computercraft/hendelser/hendelser.md
+++ b/src/computercraft/hendelser/hendelser.md
@@ -141,7 +141,7 @@ lage et enkelt spill hvor vi styrer en figur med piltastene.
   Når du kjører dette programmet vil du se at du kan bruke `pil
   høyre` til å bevege figuren mot høyre.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 De andre piltastene kan du programmere selv på samme måte. Du trenger
 da å sammenligne med kodene `keys.left`, `keys.down` og
@@ -179,7 +179,7 @@ da å sammenligne med kodene `keys.left`, `keys.down` og
   Prøv spillet! Fungerer det som du hadde trodd? Klarer du å kanskje
   legge til flere skatter?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Ved hjelp av `local maxX, maxY = term.getSize()` kan du finne
 størrelsen på skjermen. Kan du bruke dette til å begrense figuren din
@@ -242,7 +242,7 @@ se på noen enkle kommandoer for å kopiere og flytte filer.
   For å gå tilbake en katalog bruker du det spesielle navnet
   **..**. Skriv `cd ..`. Du vil nå komme tilbake til utgangspunktet.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Du har nå sett ganske mange kommandoer: `dir`, `edit`, `type`,
 `mkdir`, `move` og `cd`. I tillegg finnes også `delete` som kan brukes
@@ -552,7 +552,7 @@ siste linjen setter tekstfargen tilbake til hvit.
 Om du vil se hvordan dette virker kan du prøve å lage en **Advanced
 Computer**, og kjøre programmet `hello` på den.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Prøv å se på noen av de andre programmene du kjenner til, som for
 eksempel `cd`, `go` eller `refuel`. Du må kanskje lete litt i
@@ -614,7 +614,7 @@ datamaskin, men har noen ekstra muligheter.
   end
   ```
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Kan du legge til farger i tegneprogrammet? Se tilbake på
 `hello`-programmet hvordan du kan bruke `term.setTextColour()` til å

--- a/src/computercraft/introduksjon_til_computercraft/introduksjon_til_computercraft.md
+++ b/src/computercraft/introduksjon_til_computercraft/introduksjon_til_computercraft.md
@@ -101,7 +101,7 @@ vil se at `heiverden` er på listen over programmer.
 - [ ] For å kjøre programmet vi har laget, skriver vi `heiverden` og
 trykker enter.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Klarer du å endre på programmet slik at det for eksempel sier hei til
 deg, eller kanskje til de som sitter ved siden av deg?
@@ -578,7 +578,7 @@ den:
   `turtle.forward()`, `turtle.back()`, `turtle.turnLeft()`,
   `turtle.turnRight()`, `turtle.up()`, `turtle.down()`.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Lag en liten kloss litt unna roboten din, omtrent som på bildet
 under. Klarer du å bruke `turtle`-kommandoene over til å plassere
@@ -800,7 +800,7 @@ Gratulerer! Du har nå programmert en robot! Legg merke til at siden
 `byggTrapp`-programmet vårt bruker `detect`-kommandoer kan det bygge
 trapper opp alle slags tårn og bratte fjellsider!
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Vi har nå laget et program som kan bygge trapper oppover. Kan du lage
 et program som kan grave trapper ned under bakken?

--- a/src/computercraft/robotinvasjon/robotinvasjon.md
+++ b/src/computercraft/robotinvasjon/robotinvasjon.md
@@ -235,7 +235,7 @@ til å flytte roboten dit vi vil ha den:
   `turtle.forward()`, `turtle.back()`, `turtle.turnLeft()`,
   `turtle.turnRight()`, `turtle.up()`, `turtle.down()`.
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Lag en liten kloss litt unna roboten din, omtrent som på bildet
 under. Klarer du å bruke `turtle`-kommandoene over til å plassere

--- a/src/computercraft/sprettball/sprettball.md
+++ b/src/computercraft/sprettball/sprettball.md
@@ -465,7 +465,7 @@ reklamebannere.
   end
   ```
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Det er flere måter å gjøre `reklame`-programmet enda bedre på. Her er
 to forslag:

--- a/src/elm/03_moduler_elm_reactor/03_moduler_elm_reactor.md
+++ b/src/elm/03_moduler_elm_reactor/03_moduler_elm_reactor.md
@@ -55,7 +55,7 @@ Nå leser Elm gjennom filen din og gjør den om til vanlig HTML!
   - Last nettleseren på nytt.
   - Skjedde det noe?
 
-## Ting du kan prøve {.try}
+## Ting du kan prøve {.challenge}
 - [ ] For å åpne forskjellige programmer direkte fra nettsiden din, kan du skrive nettadressen slik: ```localhost:8000/hei.elm```. Bare bytt ut filnavnet!
 - [ ] Hva skjer når du åpner ```hei.elm``` direkte i nettleseren?
 

--- a/src/elm/04_input/04_input.md
+++ b/src/elm/04_input/04_input.md
@@ -205,7 +205,7 @@ view model =
     ]
 ```
 
-## Ting du kan prøve {.try}
+## Ting du kan prøve {.challenge}
 - [ ] Utvid nettsiden med en knapp som snur alle ordene i setningen tilbake til rett vei
 - [ ] Tekst kan manipuleres med mange forskjellige innebygde funksjoner som `String.repeat` (gjenta en tekst), `String.toUpper` (gjør alle BOKSTAVENE TIL STORE BOKSTAVER)
 - [ ] Se full liste av hva man kan gjøre med tekst [i dokumentasjonen (på engelsk)](http://package.elm-lang.org/packages/elm-lang/core/5.1.1/String)

--- a/src/processing/farger/farger.md
+++ b/src/processing/farger/farger.md
@@ -180,7 +180,7 @@ fargen på bakgrunnen, så la oss se hva vi kan gjøre med fargene til former.
 
   Nå er omrisset tre piksler bredt.
 
-## Eksperimenter {.try}
+## Eksperimenter {.challenge}
 
 - [ ] Prøv forskjellige bakgrunnsfarger. Hvordan synes du forskjellige
   bakgrunnsfarger passer sammen med fargene på sirkelen?
@@ -568,7 +568,7 @@ likevel være enklere med tre variabler.
   om du bytter til RGB, `colorMode(RGB, 255);`, etter at du har lagd
   fargene ovenfor?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 - [ ] Ta utgangspunkt i punktet hvor du blandet farger med
   `lerpColor`. Kan du tegne et ansikt eller en annen figur med

--- a/src/processing/mangekanter/mangekanter.md
+++ b/src/processing/mangekanter/mangekanter.md
@@ -80,7 +80,7 @@ på datamaskinen.
 - [ ] Lagre programmet som Firkant ved å trykke på **Ctrl+S** eller
   velg **File --> Save** i menyen.
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du lage et rektangel som ikke er kvadratisk, altså hvor bredden
   og høyden er forskjellig? Husk at vi vil at den skal sprette idet
@@ -158,7 +158,7 @@ legge til noen ekstra mellomrom for å få ting på linje. Merk at om man
 bruker automatisk formatering av koden i Processing, vil den fjerne
 mellomrom den mener er overflødig.
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du tegne trekanten motsatt vei, sånn at den ser ut som en
   pil som peker oppover istedenfor nedover?
@@ -311,7 +311,7 @@ arrayer. Du kommer til å se mange slike i fremtidige oppgaver. Løkker
 kan kreve litt øving før man blir god på det, men etter hvert blir man
 veldig glad for at man slipper å skrive den samme koden mange ganger.
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Det går også an å lage firkanter hvor man plasserer hvert hjørne for
   seg. Da bruker man funksjonen `quad` istedenfor `rect`. Prøv å endre
@@ -416,7 +416,7 @@ oppgave:
 
 ![](SprettendePolygon.gif "En hvit mangekant spretter rundt på en svart bakgrunn.")
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du bruke `random` til å få hjørnene til å endre hastighet når de
   treffer kanten av vinduet?

--- a/src/processing/pingpong/pingpong.md
+++ b/src/processing/pingpong/pingpong.md
@@ -67,7 +67,7 @@ Vår begynnelse kommer til å ligne på det vi gjorde i [den sprettende ballen](
 - [ ] Lagre programmet som PingPong ved å trykke på **Ctrl+S** eller
 velg **File --> Save** i menyen.
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du endre størrelsen på ballen?
 - [ ] Kan du endre farten til ballen?
@@ -94,7 +94,7 @@ I Ping pong skal du hindre at ballen faller bak rekkerten. For at det skal være
 
   ![](gjennommaal.gif "En ball går igjennom venstre vegg")
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du få ballen til å dukke opp et annet sted etter den har gått igjennom veggen?
 
@@ -139,7 +139,7 @@ Nå som ballen kan falle igjennom den venstre veggen, så må vi få på plass e
 
 ![](spretterPaRekkert.gif "Ballen spretter på rekkerten")
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du gjøre rekkerten mindre?
 - [ ] Kan du endre plasseringen til rekkerten?
@@ -193,7 +193,7 @@ Til:
 
 kan du styre opp med **W**. Hva tror du at du må gjøre for å kunne styre ned med **S**?
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du endre farten rekkerten beveger seg i?
 - [ ] Kan du legge til en rekkert på den andre siden slik at to spillere kan spille mot hverandre?

--- a/src/processing/sprettende_ball/sprettende_ball.md
+++ b/src/processing/sprettende_ball/sprettende_ball.md
@@ -59,7 +59,7 @@ i Processing og andre programmeringsspråk.
 | }    | Alt Gr + 0             | Shift + Alt + 9             |
 
 
-## Utforsking {.try}
+## Utforsking {.challenge}
 
 Hva skjer hvis du:
 
@@ -278,7 +278,7 @@ Hvis du ikke vil miste de forskjellige stegene i denne oppgaven kan du bruke
 **File -> Save as** ved å trykke **Ctrl + Shift + S**. Lagre programmet med et
 annet navn slik at du beholder de forskjellige variantene.
 
-## Utforsking {.try}
+## Utforsking {.challenge}
 
 Kan du endre `x` og `y` inni `draw` slik at sirkelen beveger seg:
 
@@ -356,7 +356,7 @@ I `draw` ser vi en del nytt som du ikke har sett før.
   vil den endres til å bli negativ (+ - = -). Dersom farten er negativ får vi to
   minus, som er positiv (- - = +).
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Kan du kombinere to og to av `if`-setningene ved å bruke `||`?  `||` betyr
   eller. Her er et eksempel: `if (x < 1 || x > 10)`, hvis x er under 1 *eller*

--- a/src/processing/trigonometri/trigonometri.md
+++ b/src/processing/trigonometri/trigonometri.md
@@ -181,7 +181,7 @@ spisser.
 
 ![](Oktagram.png "Vinkelen mellom en spiss, sentrum og spissen etter nabospissen i en åttekantet stjerne er 2 · 360° / 8 = 90°.")
 
-## Utfordring {.try}
+## Utfordring {.challenge}
 
 - [ ] Nå ser det nok ut som om det mangler noen streker i stjernen
   din. Kan du få tegnet opp de siste kantene ved å tegne opp den første

--- a/src/python/kuprat/kuprat.md
+++ b/src/python/kuprat/kuprat.md
@@ -255,7 +255,7 @@ omtrent hva som helst.
 
   Lagre og kjør programmet. Blir snakkeboblen riktig størrelse?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Kan du tegne andre dyr eller figurer som også kan snakke? Prøv
 eventuelt å gjøre små endringer på utseendet til kua, for eksempel kan

--- a/src/python/skilpaddefraktaler/skilpaddefraktaler.md
+++ b/src/python/skilpaddefraktaler/skilpaddefraktaler.md
@@ -431,7 +431,7 @@ trekanter.
   fraktalen er også ganske kjent, og går ofte under navnet
   Sierpinski-trekanten.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 Det finnes mange fraktaler, og du kan lage dine helt egne også!
 

--- a/src/python/skilpaddekunst/skilpaddekunst.md
+++ b/src/python/skilpaddekunst/skilpaddekunst.md
@@ -396,7 +396,7 @@ bare tegner kjedelige mangekanter.
   `spiral`. Finner du noen verdier som gir spesielt fine bilder synes
   du?
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 Kombiner de forskjellige funksjonene vi har laget, `polygon`,
 `polylines` og `spiral` med de andre skilpadde-kommandoene du har lært

--- a/src/python/skilpaddeskolen/skilpaddeskolen.md
+++ b/src/python/skilpaddeskolen/skilpaddeskolen.md
@@ -249,6 +249,6 @@ Hva om vi gjør litt tilfeldige sprell rett før vi er ferdige?  Vi kan be datam
 
   Ved å bruke `choice()` og `randrange()` kan vi be datamaskinen om å velge farge, størrelse og form for oss, og det kommer til å bli forskjellig resultat nesten hver eneste gang du kjører programmet.
 
-## Flere ting å prøve {.try}
+## Flere ting å prøve {.challenge}
 
 Hva med å prøve flere farger, eller å endre tallene? Hva skjer?

--- a/src/python/skilpaddetekst/skilpaddetekst.md
+++ b/src/python/skilpaddetekst/skilpaddetekst.md
@@ -345,7 +345,7 @@ Vi trenger en funksjon for å skrive blanke tegn, og  vi trenger å oversette fr
 
 - [ ] Kjør koden og se resultatet ditt!
 
-## Kjøre koden uendelig mange ganger {.try}
+## Kjøre koden uendelig mange ganger {.challenge}
 
 Dersom du ønsker å kjøre koden uendelig mange ganger, kan du endre `main`-funksjonen til:
 

--- a/src/scratch/3d_flakser/3d_flakser_1.md
+++ b/src/scratch/3d_flakser/3d_flakser_1.md
@@ -221,7 +221,7 @@ du har skrevet så langt.
   i Flappy Bird og Flaksefugl. Prøv deg på disse utfordringene hvis
   du har mer tid igjen.
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Er det mulig å styre figuren gjennom alle ringene? Husk at spillet
   skal være akkurat passe vanskelig, og ihvertfall ikke umulig. Gå

--- a/src/scratch/3d_flakser/3d_flakser_2.md
+++ b/src/scratch/3d_flakser/3d_flakser_2.md
@@ -219,7 +219,7 @@ ring-figuren.
 Nå er vi igrunn ferdig med det viktigste i spillet. Men det er
 fremdeles masse spennende igjen du kan prøve:
 
-# Ting å prøve {.try}
+# Ting å prøve {.challenge}
 
 - [ ] Lag en meny.
 

--- a/src/scratch/data_navn/data_navn.md
+++ b/src/scratch/data_navn/data_navn.md
@@ -148,7 +148,7 @@ __Klikk på koden din.__
 - [ ] Legg også en `når grønt flagg klikkes`{.b}-kloss på toppen av koden din, slik
   at du kan starte programmet ved å klikke på det grønne flagget.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Dette er et veldig enkelt eksempel på hva man kan gjøre med navnelistene (og
   det har noen problemer: for eksempel finner ikke katten dobbeltnavn

--- a/src/scratch/enarmet_banditt/enarmet_banditt.md
+++ b/src/scratch/enarmet_banditt/enarmet_banditt.md
@@ -65,7 +65,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Endrer figuren drakt i et fornuftig tempo?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 Tilpass tiden i `vent`{.blockcontrol}-klossen. Hvilke tall gjør spillet
 for vanskelig eller for lett?
@@ -204,7 +204,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Hvordan må vi forandre skriptet dersom vi legger til en annen drakt?
 
-## Ting å prøve{.try}
+## Ting å prøve{.challenge}
 
  __Gjør spillet vanskeligere!__
 

--- a/src/scratch/flagg/flagg.md
+++ b/src/scratch/flagg/flagg.md
@@ -104,7 +104,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Flytter sirkelen seg til det nye sentrumet?
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Legg til en ny variabel, `(radius)`{.b}, som også gjelder kun _for denne
   figuren_. Kan du bruke denne til å styre hvor stor sirkelen er? Det vil si,
@@ -265,7 +265,7 @@ Nå skal vi se hvordan vi kan tegne flagget i forskjellige farger.
   `(flagg)`{.b} til `rhb` for å se dette).
 
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Tegn egne flagg. Om du trenger flere farger er det bare å lage flere
   drakter. Pass på at hver drakt har en bokstav eller tall som navn.

--- a/src/scratch/fyrverkeri/fyrverkeri.md
+++ b/src/scratch/fyrverkeri/fyrverkeri.md
@@ -139,7 +139,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Kommer det raketter flyvende?
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 - [ ] Prøv å få noen raketter til å bevege seg litt saktere eller fortere
   enn andre.
@@ -299,7 +299,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Vokser eksplosjonen gradvis?
 
-## Utfordringer {.try}
+## Utfordringer {.challenge}
 
 Prøv å gjøre hver eksplosjon enda mer unik: endre størrelsen og
 veksthastigheten for eksplosjonen.

--- a/src/scratch/halloweenimasjon/halloweenimasjon.md
+++ b/src/scratch/halloweenimasjon/halloweenimasjon.md
@@ -375,7 +375,7 @@ __Klikk på det grønne flagget.__
 
 # Steg 6: Enda flere animasjoner? {.activity}
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 Vi har nå sett noen eksempler på hvordan vi kan lage skumle
 halloween-animasjoner. Prøv å bruk lignende teknikker for å lage dine

--- a/src/scratch/hoppehelt/hoppehelt.md
+++ b/src/scratch/hoppehelt/hoppehelt.md
@@ -168,7 +168,7 @@ __Klikk på det grønne flagget.__
   `skjul`{.blocklooks}-kloss rett før
   `spill tone`{.blocksound}-klossen.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 Før vi går videre skal vi se på et par måter vi kan gjøre hver enkelt
 boks litt spesiell og forskjellig fra de andre på. Prøv å
@@ -306,7 +306,7 @@ __Klikk på det grønne flagget.__
   kommer! Dette har plutselig blitt et ganske vanskelig spill som
   krever konsentrasjon og koordinasjon!
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 Oppgaven slutter her, men det er jo fortsatt mange spennende ting du
 kan gjøre med spillet ditt for å gjøre det enda bedre.

--- a/src/scratch/hva_er_det/hva_er_det.md
+++ b/src/scratch/hva_er_det/hva_er_det.md
@@ -106,7 +106,7 @@ __Klikk på det grønne flagget.__
 - [ ] Får du fremdeles nye ting på tavlen når du klikker på det grønne
   flagget?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Prøv å __endre poengsummen__ fra start, samt hvor mye den skal
   __forandre seg__ for hver gang den går gjennom løkken. Hvordan

--- a/src/scratch/hvor_i_all_verden/hvor_i_all_verden_1.md
+++ b/src/scratch/hvor_i_all_verden/hvor_i_all_verden_1.md
@@ -318,7 +318,7 @@ gang skal vi se på hvordan vi kan lage et større kart ved å få
 bakgrunnen til å flytte på seg. Vi skal også gjøre spillet
 vanskeligere ved å legge til flere reisemål.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Tenk over hvordan du kan legge til flere reisemål! Prøv å lage kode
   som gjør dette!

--- a/src/scratch/hvor_i_all_verden/hvor_i_all_verden_2.md
+++ b/src/scratch/hvor_i_all_verden/hvor_i_all_verden_2.md
@@ -336,7 +336,7 @@ spillet ferdig ved å lage lister som gjør det enklere å lage en
 tilfeldig reiserute. Vi skal også se hvordan vi kan lage en intro til
 spillet, samt legge på en tidsbegrensning og poengsum.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Kan du legge til flere reisemål på egen hånd? Husk at det er lurt å
   gjøre reisemålet synlig mens du tester. Da blir det enklere å finne

--- a/src/scratch/hvor_i_all_verden/hvor_i_all_verden_3.md
+++ b/src/scratch/hvor_i_all_verden/hvor_i_all_verden_3.md
@@ -300,7 +300,7 @@ Nå er vi ferdige med spillet! Veldig bra! Vi håper du har lært mye
 spennende gjennom disse leksjonene.  Du kan dele spillet med familie
 og venner ved å trykke `Legg ut` øverst til høyre på skjermen.
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 - [ ] Selv om leksjonene er ferdige betyr ikke det at du ikke kan
   videreutvikle spillet ditt. En enkel utvidelse er å legge på flere

--- a/src/scratch/jafsefisk/jafsefisk.md
+++ b/src/scratch/jafsefisk/jafsefisk.md
@@ -83,7 +83,7 @@ __Klikk på det grønne flagget.__
   slutt
   ```
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 Hvis du vil kan du forandre tallene i skriptet, og se hvordan det
 forandrer bevegelsene.
@@ -131,7 +131,7 @@ __Klikk på det grønne flagget.__
 *For øyeblikket samspiller ikke JafseFisk og byttedyret med
  hverandre. Det skal vi gjøre noe med i neste steg.*
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Prøv å forandre tallene for `gå (2) steg`{.b} og `tilfeldig
   tall fra (-20) til (20)`{.b}. Hvordan forandrer det byttedyrets

--- a/src/scratch/kingkong/kingkong.md
+++ b/src/scratch/kingkong/kingkong.md
@@ -295,7 +295,7 @@ Vi har nå laget et ganske enkelt spill. Men det er flere ting du kan
 prøve på egen hånd! Nedenfor er noen forslag, men du har kanskje egne
 ideer til hvordan spillet kan videreutvikles?
 
-### Prøv selv {.try}
+### Prøv selv {.challenge}
 
 - [ ] Legg til lydeffekter! Kanskje litt motorlyd fra flyene, og så klart
   trenger vi en lyd når King Kong blir truffet av flyene.

--- a/src/scratch/pingviner_pa_tur/pingviner_pa_tur.md
+++ b/src/scratch/pingviner_pa_tur/pingviner_pa_tur.md
@@ -266,7 +266,7 @@ __Klikk på det grønne flagget.__
 - [ ] Etter at pingvinen har vært hjemme i 7 sekunder tar den seg en ny tur. Dukker
   den opp på et nytt tilfeldig sted?
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 Vi har nå laget et lite spill sammen, men prøv gjerne å utvikle det videre. Her
 er noen ideer:

--- a/src/scratch/snurrige_figurer/snurrige_figurer.md
+++ b/src/scratch/snurrige_figurer/snurrige_figurer.md
@@ -65,7 +65,7 @@ innimellom.
 
 + I menyen `Fil` kan du velge `Lagre nå` for å lagre prosjektet.
 
-## Endre en eksisterende figur {.try}
+## Endre en eksisterende figur {.challenge}
 
 Selv om det ikke finnes en trekant i figurbiblioteket, kan vi gjøre om en av de
 andre figurene til en trekant. Om du allerede har laget en trekant trenger du
@@ -281,7 +281,7 @@ __Trykk på C-tasten.__
   send melding [flytt og snurr v]
   ```
 
-### Flere ideer {.try}
+### Flere ideer {.challenge}
 
 Tenk på andre ting du kan gjøre for å lage interessante snurrige figurer. Her er
 noen ideer:

--- a/src/scratch/soloball/soloball.md
+++ b/src/scratch/soloball/soloball.md
@@ -100,7 +100,7 @@ __Klikk på det grønne flagget.__
   tilbake og endre på kattefiguren senere hvis du oppdager noe som
   kunne vært bedre.
 
-## Hva skjedde? {.try}
+## Hva skjedde? {.challenge}
 
 Selv om ikke endret programmet vårt oppfører katten seg veldig
 annerledes. Skjønner du hvorfor?
@@ -489,7 +489,7 @@ sist snudde.
   slutt
   ```
 
-## Prøv selv {.try}
+## Prøv selv {.challenge}
 
 I disse ekstrastegene har vi sett på noen måter vi kan gjøre spillet
 bedre og mer spennende på. Her er enda flere ideer:

--- a/src/scratch/spokelsesjakten/spokelsesjakten.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten.md
@@ -98,7 +98,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Flyr spøkelset riktig vei?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] __Endre hastighetsvariabelen__, slik at spøkelset går raskere eller
   saktere.
@@ -138,7 +138,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Forsvinner det og dukker opp igjen helt tilfeldig?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Prøv å __endre tallene i koden__ der det står `tilfeldig tall fra _
   til _`{.blockoperators}. Hva skjer hvis du velger veldig store
@@ -171,7 +171,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Forsvinner spøkelset med en tryllelyd når du klikker på det?
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Spør de voksne om du kan ta opp en egen lyd. Denne kan du bruke i
   stedet for tryllelyden.
@@ -224,7 +224,7 @@ __Klikk på det grønne flagget.__
 
 __Klikk på det grønne flagget.__
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Hvordan kan du få spøkelset til å gå fortere etter at spillet er i
   gang?
@@ -265,7 +265,7 @@ __Klikk på det grønne flagget.__
 
 Gratulerer! Da har du gjort alt riktig!
 
-## Ting å prøve {.try}
+## Ting å prøve {.challenge}
 
 - [ ] Hvor mange spøkelser synes du spillet fungerer best med? __Legg til
   flere__ og prøv!

--- a/src/swift/hei_verden/hei_verden.md
+++ b/src/swift/hei_verden/hei_verden.md
@@ -101,7 +101,7 @@ Det er viktig å slippe strekene eksakt som det står i de to stegene over! Diss
 
   ![](change_label.png)
 
-## Utfordring - Variabler {.try}
+## Utfordring - Variabler {.challenge}
 Prøv å definer en variabel nedenfor `@IBOutlet weak var etikett: UILabel!`, og sett den til å være ditt navn. Klarer du å få `Label` til å vise verdien av variabelen ved å endre `etikett.text`?
 
 # Steg 4: Få input fra tekstfelt {.activity}
@@ -120,7 +120,7 @@ Nå skal vi legge inn et tekstfelt i appen, så vi kan ta det brukeren skriver i
 
   ![](textfield_input.png)
 
-## Utfordring - Kan du lage din egen versjon? {.try}
+## Utfordring - Kan du lage din egen versjon? {.challenge}
 Nå som du har lært det grunnleggende, hvorfor ikke lage en app som har flere knapper og tekstfelt? Kanskje du kan få den til å fortelle en morsom historie basert på ord brukeren skriver inn? Vis gjerne appen til bekjente og be om tilbakemeldinger!
 
 ## Noen spørsmål? {.protip}

--- a/src/web/del_inn_nettsiden/del_inn_nettsiden.md
+++ b/src/web/del_inn_nettsiden/del_inn_nettsiden.md
@@ -281,7 +281,7 @@ Det finnes flere måter å skive farger i CSS på. Vi har nå brukt kjente ord s
 
 Vi skal se enda mer på CSS etter vi har lært litt mer HTML.
 
-## Utfordring {.try}
+## Utfordring {.challenge}
 - [ ] Gå inn på [w3schools.com/css](http://w3schools.com/css) og se om du finner en flere “properties” du kan endre på.
 
 

--- a/src/web/en_hjemmeside/en_hjemmeside.md
+++ b/src/web/en_hjemmeside/en_hjemmeside.md
@@ -133,7 +133,7 @@ For å linke tilbake fra `om_meg.html` til `om_meg_side_2.html` må du skrive de
 
 __Gratulerer! Du har laget ditt eget nettsted.__
 
-## Ting du kan prøve {.try}
+## Ting du kan prøve {.challenge}
 
 - [ ] Hvordan kan du linke til en annen side på nettet? (Hint: prøv å legge til `http://` og deretter adressen til nettstedet du vil koble til)
 - [ ] I likhet med forslaget ovenfor, hvordan ville du legge til et bilde fra et sted på nettet i stedet for fra datamaskinen? (Hint: igjen, prøve å legge til `http://` og adressen til bildet)

--- a/src/web/forsvunnet_katt/forsvunnet_katt.md
+++ b/src/web/forsvunnet_katt/forsvunnet_katt.md
@@ -178,7 +178,7 @@ Siden vår vil nå se ca slik ut:
 
 Til venstre har vi HTML-koden og til høyre har vi hvordan nettleseren viser siden vår.
 
-## Hva kan du gjøre videre? {.try}
+## Hva kan du gjøre videre? {.challenge}
 
 - [ ] Er det noe annet du kan legge til websiden som vil hjelpe folk å finne Felix? Mer informasjon? Hvordan ville du lagt til et kart over hvor han forsvant?
 

--- a/src/web/introduksjon_til_web/introduksjon_til_web.md
+++ b/src/web/introduksjon_til_web/introduksjon_til_web.md
@@ -114,7 +114,7 @@ Det finnes også noen tagger som vi alltid må ha med i HTML dokumenter:
 - [ ] Lagre siden og åpne den i nettleseren.
 - [ ] Hvordan påvirker rekkefølgen av koden rekkefølgen på det som vises i nettleseren?
 
-## Ting du kan prøve {.try}
+## Ting du kan prøve {.challenge}
 
 - [ ] Lag din egen paragraf med tekst.
 - [ ] Lag en link som peker til en annen del av siden. **Hint:** Det har noe med ID å gjøre, se etter en link som peker til katten.

--- a/src/web/layout/layout.md
+++ b/src/web/layout/layout.md
@@ -274,7 +274,7 @@ __Eksempel:__
 
 __TADA! Du har nå laget en flott nettside som du kan bygge videre på!__
 
-## Ting å jobbe videre med {.try}
+## Ting å jobbe videre med {.challenge}
 - [ ] Bruk [w3schools.com/css/css_link.asp](http://www.w3schools.com/css/css_link.asp) til å legge til forandring på linkene når du holder over dem
 - [ ] Legg til enda en side for eksempel "Mitt favorittspill". Skriv om det, legg til bilder og videoer som er relatert til spillet.
 - [ ] Legg teksten på siden i en `div`-er og sett forskjellig stil på dem

--- a/src/web/lenk_sammen_nettsider/lenk_sammen_nettsider.md
+++ b/src/web/lenk_sammen_nettsider/lenk_sammen_nettsider.md
@@ -75,5 +75,5 @@ Her er et eksempel på 3 sider som er knyttet sammen. Koden er hentet fra [“De
 ![screenshot](ressurser/om_meg.png)
 
 
-# TIPS {.try}
+# TIPS {.challenge}
 Bruk gjerne [w3schools](http://www.w3schools.com/) for å få enda mer hjelp eller lese mer om HTML-tagger. Dersom det er vanskelig språk så spør du en voksen, lærere eller veileder.

--- a/src/web/partikkel_gravitasjon/partikkel_gravitasjon.md
+++ b/src/web/partikkel_gravitasjon/partikkel_gravitasjon.md
@@ -115,7 +115,7 @@ window.onkeydown = function(inputKey) {
 ```
 - [ ] Bruk [keycode.info](http://keycode.info) til å finne ut hvilke `knapp-kode` knappen du vil bruke har.
 
-## Forklaring {.try}
+## Forklaring {.challenge}
 + `window.onkeydown` er en funksjon som sjekker om en knapp trykkes ned, dersom den gjør det, så kjøres funksjonen med `knapp-kode` `inputKey`.
 + `var key = inputKey.keyCode ? inputKey.keyCode : inputKey.which;` er en enklere måte å skrive dette på:
 ```js

--- a/src/web/publiser/publiser.md
+++ b/src/web/publiser/publiser.md
@@ -114,7 +114,7 @@ NB! Stegene over må du gjøre hver gang du skal oppdatere nettsiden din!
 
 __Gratulerer med ny hjemmeside!__ Denne kan du dele med hvem du vil ved å sende lenken `ditt-brukernavn.github.io`.
 
-# Vil du lære mer om GitHub? {.try}
+# Vil du lære mer om GitHub? {.challenge}
 GitHub er et stort tema og kan være litt komplisert og vrient i starten, men jeg hvis du vil lære mer sjekk ut tipsene under:
 + Les mer om GitHub her: [https://www.atlassian.com/git/tutorials](https://www.atlassian.com/git/tutorials)
 + Søk på `GitHub Tutorials` på [YouTube](http://youtube.com) F.eks: [GitHub for noobs](https://www.youtube.com/watch?v=BKr8lbx3uFY)

--- a/src/web/skjul_ninjaene/skjul_ninjaene.md
+++ b/src/web/skjul_ninjaene/skjul_ninjaene.md
@@ -109,7 +109,7 @@ Her finnes det ingen fasit, så du må legge til og endre kode sånn at du får 
 
 __LYKKE TIL!__
 
-## Ting du kan prøve: {.try}
+## Ting du kan prøve: {.challenge}
 - [ ] Legg gjerne til `z-index` eller endre `position` i CSS-en på de elementene du føler trenger det
 - [ ] Kan du finne ut hvordan du kan få ninjaene til å komme foran noen av gateobjektene? Hva skjer om du kopierer `<img>`-taggen for ninjaen etter `<img>`-taggen som viser objektet?
 - [ ] Klarer du å legge til flere objekter på scenen? Du kan legge til bilder fra datamaskinen din, eller finne noen på internett.

--- a/src/web/style_nettsider/style_nettsider.md
+++ b/src/web/style_nettsider/style_nettsider.md
@@ -186,7 +186,7 @@ h1 {
 Er det ikke mye større forskjell nå?
 
 
-### For de som bruker Firefox eller Chrome som nettleser. {.try}
+### For de som bruker Firefox eller Chrome som nettleser. {.challenge}
 Det finnes faktisk også en annen verdi for `text-decoration` som er `blink`. Jeg kommer ikke til å fortelle deg hva det gjør. Du må teste det. `text-decoration:blink;` (det blir litt masete etterhvert, men det er lov å gå tilbake til “underline” hvis du vil).
 
 
@@ -270,7 +270,7 @@ Men vær forsiktig, det finnes noen stiler som ikke blir videreført.
 ```
 
 
-## Videre studier {.try}
+## Videre studier {.challenge}
 
 - [ ] Hvordan ville du endret på siden for å få den til å se bedre ut? Hvorfor ikke prøve å bruke alle dine favorittfarger? Finnes din farge som et navn eller må du bruke en heksadesimal kode?
 - [ ] Hvis du blir fort ferdig kan du gå tilbake å legge på stiler for tidigere leksjoner.

--- a/src/web/tekststil/tekststil.md
+++ b/src/web/tekststil/tekststil.md
@@ -132,7 +132,7 @@ img {
 
 __Fant du en stil du liker?__
 
-## Ting å prøve ut {.try}
+## Ting å prøve ut {.challenge}
 
 - [ ] Du kan sette på kantlinjer på alle slags elementer. Prøv å sett kantlinjer på de andre elementene på siden din.
 
@@ -175,7 +175,7 @@ Deretter setter vi stilen slik at tekten er større for alle paragrafer med `cla
 
 Sammen kan du gjøre med `<div>`- og `HTML5`-taggene vi brukte i oppgaven [HTML: Del inn nettsiden](../del_inn_nettsiden/del_inn_nettsiden.html).
 
-## Ting du kan prøve: {.try}
+## Ting du kan prøve: {.challenge}
 
 - [ ] Hvordan vil du endre siden for å få den til å se bedre ut? Hvorfor ikke prøve å bruke din favorittskrifttype, farge, osv? Bruk gjerne [w3schools.com/css](http://www.w3schools.com/css/) for å utforske CSS-ens verden.
 


### PR DESCRIPTION
På codeclub lesson builder og codeclub-viewer kan man ikke se checkboxene i {.try}-boksene. 

[Se link til issue](https://github.com/kodeklubben/codeclub-viewer/issues/339)

Har brukt Atom sin innebygde replacefunksjon for å endre