### PR TITLE
Fjernet tom linje i starten av dokumentet

### DIFF
--- a/src/python/bokstaver/README.md
+++ b/src/python/bokstaver/README.md
@@ -1,4 +1,3 @@
-
 ---
 title: Lærerveiledning - Bokstaver
 level: 1
@@ -44,14 +43,14 @@ I denne oppgaven skal vi programmere skilpadder til å konstruere bokstaver og a
 
  - [ ] Eleven oppnår middels måloppnåelse ved å fullføre oppgaven.
 
- - [ ] Eleven oppnår høy måloppnåelse ved å videreutvikle egen kode basert på oppgaven. 
+ - [ ] Eleven oppnår høy måloppnåelse ved å videreutvikle egen kode basert på oppgaven.
 
- 
+
  ## Forutsetninger og utstyr {.challenge}
 
  - [ ]  __Forutsetninger__: Ingen.
 
- - [ ]  __Utstyr__: Datamaskin med Python installert. 
+ - [ ]  __Utstyr__: Datamaskin med Python installert.
 
 
 ## Fremgangsmåte
@@ -77,4 +76,3 @@ __NB:__ merk at 'red' bare er et eksempel på en farge som kan brukes. Dersom en
  ## Eksterne ressurser {.challenge}
 
  - [ ] Foreløpig ingen eksterne ressurser ...
-

--- a/src/scratch/hoppehelt/README.md
+++ b/src/scratch/hoppehelt/README.md
@@ -1,4 +1,3 @@
-
 ---
 title: Lærerveiledning - Hoppehelt
 level: 4


### PR DESCRIPTION
To av lærerveiledningene kom ikke med i cc-viewer fordi de hadde tom linje i starten av dokumentet, så YAML ble ikke lest.