### PR TITLE
Change bezier animation target

### DIFF
--- a/src/elm/05_tegne/05_tegne.md
+++ b/src/elm/05_tegne/05_tegne.md
@@ -327,7 +327,7 @@ forskjellige typer bezierkurver:
 
 ## En munn som bezierkurve {.check}
 
-- [ ] Gå til https://www.jasondavies.com/animated-bezier/
+- [ ] Gå til http://bl.ocks.org/joyrexus/5715642
 - [ ] Du kan dra i punktene. Klarer du å lage en munn?
 
 Her er en `path` med bezierkurve i Elm:


### PR DESCRIPTION
The old web page with an animated Bezier Curve editor got SSL errors, causing
the link checker to fail. Use a different application to avoid this.

This time, with just the one file that should be there.