### PR TITLE
fix syntax error in code snippet

### DIFF
--- a/src/computercraft/sprettball/sprettball.md
+++ b/src/computercraft/sprettball/sprettball.md
@@ -273,8 +273,8 @@ ballen flytter på seg.
           skjerm.write("O")
           sleep(1)
 
-          X = X - [ ] fartX                         -- ny linje
-          Y = Y - [ ] fartY                         -- ny linje
+          X = X + fartX                         -- ny linje
+          Y = Y + fartY                         -- ny linje
       end
   end
   ```


### PR DESCRIPTION
a search-and-replace operation had previously replaced code in a code snippet, which it shouldn't have touched

Solves #612 