### PR TITLE
New topic in filtertags; sound

### DIFF
--- a/filtertags/keys.md
+++ b/filtertags/keys.md
@@ -10,6 +10,7 @@ topic: #Logical AND
   - game        #Interactive programs with game elements
   - robot       #Physical objects that moves
   - animation   #Machine-made cartoons
+  - sound       #Projects involving sounds or music
 subject: #Logical OR
   - mathematics
   - science

--- a/filtertags/translation_da.md
+++ b/filtertags/translation_da.md
@@ -32,6 +32,9 @@ topic:
     animation:
       NAME: Animasjon
       TOOLTIP: Lage grafikk som beveger seg, for eksempel tegnefilmer.
+    sound:
+      NAME: Lyd
+      TOOLTIP: Programmere lyd og musikk.
 subject:
   NAME: Fag
   TAGS:

--- a/filtertags/translation_en.md
+++ b/filtertags/translation_en.md
@@ -32,6 +32,9 @@ topic:
     animation:
       NAME: Animation
       TOOLTIP: Graphics that move, like cartoons.
+    sound:
+      NAME: Sound
+      TOOLTIP: Program sound and music.
 subject:
   NAME: Fag
   TAGS:

--- a/filtertags/translation_nb.md
+++ b/filtertags/translation_nb.md
@@ -32,6 +32,9 @@ topic:
     animation:
       NAME: Animasjon
       TOOLTIP: Lage grafikk som beveger seg, for eksempel tegnefilmer.
+    sound:
+      NAME: Lyd
+      TOOLTIP: Programmere lyd og musikk.
 subject:
   NAME: Fag
   TAGS:

--- a/filtertags/translation_nn.md
+++ b/filtertags/translation_nn.md
@@ -32,6 +32,9 @@ topic:
     animation:
       NAME: Animasjon
       TOOLTIP: Lage grafikk som rører seg, til dømes teiknefilmar.
+    sound:
+      NAME: Ljod
+      TOOLTIP: Programmere ljod og musikk.
 subject:
   NAME: Fag
   TAGS:

--- a/filtertags/translation_sv.md
+++ b/filtertags/translation_sv.md
@@ -31,7 +31,10 @@ topic:
       TOOLTIP: Programmera fysiska objekt som rör på sig.
     animation:
       NAME: Animation
-      TOOLTIP: Laga grafik som rör på seg, for eksempel tecknad film.
+      TOOLTIP: Laga grafik som rör på seg, till exempel tecknad film.
+    sound:
+      NAME: Ljud
+      TOOLTIP: Programmera ljud och musik.
 subject:
   NAME: Ämne
   TAGS:

--- a/src/sonic_pi/index.md
+++ b/src/sonic_pi/index.md
@@ -3,7 +3,8 @@ title: Sonic Pi
 language: nb
 external: http://sonic-pi.mehackit.org/index_no.html
 tags:
-    topic: [text_based, music]
+    topic: [text_based, sound]
+    subject: [music, programming]
     grade: [primary, secondary, junior]
 ---
 


### PR DESCRIPTION
Added `sound` as a topic in filtertags, to cover projects involving sound and music. Used sound instead of music to avoid clashes with `subject: music`.

Added `topic: sound`  to Sonic-Pi course, and fixed `music` wrongly tagged as `topic`.