### PR TITLE
Filtertags legg til spraak

### DIFF
--- a/filtertags/keys.md
+++ b/filtertags/keys.md
@@ -1,4 +1,10 @@
 ---
+language: #Logical OR
+  - nb  # Norwegian bokmål
+  - nn  # Norwegian nynorsk
+  - sv  # Swedish
+  - da  # Danish
+  - en  # English
 topic: #Logical AND
   - app         #Tasks for making apps to mobiles and tablets such as App Inventor and Swift
   - electronics #Includes external devices such as Microbit, Arduino, Raspberry Pi, Lego Mindstorms.
@@ -11,7 +17,7 @@ topic: #Logical AND
   - robot       #Physical objects that moves
   - animation   #Machine-made cartoons
   - sound       #Projects involving sounds or music
-subject: #Logical OR
+subject: #Logical AND
   - mathematics
   - science
   - programming
@@ -21,7 +27,7 @@ subject: #Logical OR
   - english
   - arts_and_crafts
   - social_science
-grade: #Logical OR
+grade: #Logical AND
   - preschool   #Projects aimed at preschool students
   - primary     #Projects aimed at students in grade 1.-4.
   - secondary   #Projects aimed at students in grade 5.-7.

--- a/filtertags/translation_da.md
+++ b/filtertags/translation_da.md
@@ -4,13 +4,13 @@ language:
   TAGS:
     nb:
       NAME: Norsk bokmål
-    nn
+    nn:
       NAME: Norsk nynorsk
-    sv
+    sv:
       NAME: Svenska
-    da
+    da:
       NAME: Dansk
-    en
+    en:
       NAME: English
 topic:
   NAME: Tema
@@ -86,5 +86,5 @@ grade:
       TOOLTIP: Ungdom 13-15 år
     senior:
       NAME: Videregående skole
-      NAME: Ungdom 16-18 år
+      TOOLTIP: Ungdom 16-18 år
 ---

--- a/filtertags/translation_da.md
+++ b/filtertags/translation_da.md
@@ -1,4 +1,17 @@
 ---
+language:
+  NAME: Språk
+  TAGS:
+    nb:
+      NAME: Norsk bokmål
+    nn
+      NAME: Norsk nynorsk
+    sv
+      NAME: Svenska
+    da
+      NAME: Dansk
+    en
+      NAME: English
 topic:
   NAME: Tema
   TAGS:

--- a/filtertags/translation_en.md
+++ b/filtertags/translation_en.md
@@ -1,4 +1,17 @@
 ---
+language:
+  NAME: Language
+  TAGS:
+    nb:
+      NAME: Norsk bokmål
+    nn
+      NAME: Norsk nynorsk
+    sv
+      NAME: Svenska
+    da
+      NAME: Dansk
+    en
+      NAME: English
 topic:
   NAME: Topic
   TAGS:

--- a/filtertags/translation_en.md
+++ b/filtertags/translation_en.md
@@ -4,13 +4,13 @@ language:
   TAGS:
     nb:
       NAME: Norsk bokmål
-    nn
+    nn:
       NAME: Norsk nynorsk
-    sv
+    sv:
       NAME: Svenska
-    da
+    da:
       NAME: Dansk
-    en
+    en:
       NAME: English
 topic:
   NAME: Topic
@@ -49,7 +49,7 @@ topic:
       NAME: Sound
       TOOLTIP: Program sound and music.
 subject:
-  NAME: Fag
+  NAME: Subject
   TAGS:
     mathematics:
       NAME: Mathematics

--- a/filtertags/translation_nb.md
+++ b/filtertags/translation_nb.md
@@ -4,13 +4,13 @@ language:
   TAGS:
     nb:
       NAME: Norsk bokmål
-    nn
+    nn:
       NAME: Norsk nynorsk
-    sv
+    sv:
       NAME: Svenska
-    da
+    da:
       NAME: Dansk
-    en
+    en:
       NAME: English
 topic:
   NAME: Tema
@@ -86,5 +86,5 @@ grade:
       TOOLTIP: Ungdom 13-15 år
     senior:
       NAME: Videregående skole
-      NAME: Ungdom 16-18 år
+      TOOLTIP: Ungdom 16-18 år
 ---

--- a/filtertags/translation_nb.md
+++ b/filtertags/translation_nb.md
@@ -1,4 +1,17 @@
 ---
+language:
+  NAME: Språk
+  TAGS:
+    nb:
+      NAME: Norsk bokmål
+    nn
+      NAME: Norsk nynorsk
+    sv
+      NAME: Svenska
+    da
+      NAME: Dansk
+    en
+      NAME: English
 topic:
   NAME: Tema
   TAGS:

--- a/filtertags/translation_nn.md
+++ b/filtertags/translation_nn.md
@@ -4,13 +4,13 @@ language:
   TAGS:
     nb:
       NAME: Norsk bokmål
-    nn
+    nn:
       NAME: Norsk nynorsk
-    sv
+    sv:
       NAME: Svenska
-    da
+    da:
       NAME: Dansk
-    en
+    en:
       NAME: English
 topic:
   NAME: Tema
@@ -86,5 +86,5 @@ grade:
       TOOLTIP: Ungdom 13-15 år
     senior:
       NAME: Vidaregåande skule
-      NAME: Ungdom 16-18 år
+      TOOLTIP: Ungdom 16-18 år
 ---

--- a/filtertags/translation_nn.md
+++ b/filtertags/translation_nn.md
@@ -1,4 +1,17 @@
 ---
+language:
+  NAME: Språk
+  TAGS:
+    nb:
+      NAME: Norsk bokmål
+    nn
+      NAME: Norsk nynorsk
+    sv
+      NAME: Svenska
+    da
+      NAME: Dansk
+    en
+      NAME: English
 topic:
   NAME: Tema
   TAGS:

--- a/filtertags/translation_sv.md
+++ b/filtertags/translation_sv.md
@@ -4,13 +4,13 @@ language:
   TAGS:
     nb:
       NAME: Norsk bokmål
-    nn
+    nn:
       NAME: Norsk nynorsk
-    sv
+    sv:
       NAME: Svenska
-    da
+    da:
       NAME: Dansk
-    en
+    en:
       NAME: English
 topic:
   NAME: Tema

--- a/filtertags/translation_sv.md
+++ b/filtertags/translation_sv.md
@@ -1,4 +1,17 @@
 ---
+language:
+  NAME: Språk
+  TAGS:
+    nb:
+      NAME: Norsk bokmål
+    nn
+      NAME: Norsk nynorsk
+    sv
+      NAME: Svenska
+    da
+      NAME: Dansk
+    en
+      NAME: English
 topic:
   NAME: Tema
   TAGS:


### PR DESCRIPTION
Trengs for PR https://github.com/kodeklubben/codeclub-viewer/pull/424

Legger til språk i filtertags, slik at det blir enklere i codeclub_viewer å behandle alle filter under ett. Riktignok er det slik at alle oversettelser av språk er lik (siden vi alltid skriver språkene på morsmålet sitt), men det gir mulighet for å endre, og som sagt, enklere å forholde seg til når alt er uniformt.

Retter også opp en liten feil.