### PR TITLE
Wrote basic linter

### DIFF
--- a/linter/LKK_auto_linter.py
+++ b/linter/LKK_auto_linter.py
@@ -1,0 +1,56 @@
+import pickle
+import os
+import glob
+
+from pathlib import Path
+from collections import defaultdict
+
+PATH_2_LAST_LINTED_TIMES = "./last_auto_linted_times.pkl"
+PATH_2_SRC = '../src'
+PATH_2_LINTER = './LKK_auto_linter.sh'
+
+
+def load_last_modified_times():
+    linted_times_file = Path(PATH_2_LAST_LINTED_TIMES)
+    if linted_times_file.is_file():
+        # file exists
+        # read python dict back from the file
+        pkl_file = open(PATH_2_LAST_LINTED_TIMES, 'rb')
+        linted_times_ = pickle.load(pkl_file)
+        pkl_file.close()
+    else:
+        linted_times_ = defaultdict(int)
+    return linted_times_
+
+
+def save_last_modified_times(linted_times_):
+    # write python dict to a file
+    output = open(PATH_2_LAST_LINTED_TIMES, 'wb')
+    pickle.dump(linted_times_, output)
+    output.close()
+
+
+def get_md_files(path):
+    return glob.glob(path + '/**/*.md', recursive=True)
+
+
+def main():
+    linted_times_ = load_last_modified_times()
+    md_files = get_md_files(PATH_2_SRC)
+
+    for md_file in md_files:
+        # Check if the file has been updated since last linting
+        last_modified_time = os.path.getmtime(md_file)
+        if last_modified_time > linted_times_[md_file]:
+            # If so auto lint the file again
+            os.system('{} {}'.format(PATH_2_LINTER, md_file))
+            # ensures the last modified date is truly updated
+            os.system('touch {}'.format(md_file))
+            # Update when the file was last linted
+            linted_times_[md_file] = os.path.getmtime(md_file)
+    save_last_modified_times(linted_times_)
+
+
+if __name__ == "__main__":
+
+    main()

--- a/linter/LKK_auto_linter.sh
+++ b/linter/LKK_auto_linter.sh
@@ -1,0 +1,107 @@
+
+#!/usr/bin/env bash
+
+# LKK_auto_linter
+#
+# Usage: First allow the script to be run
+#
+#   chmod +x ./LKK_auto_linter.sh
+#
+# Now you can run the script on any markdown (md) file
+#
+#   ./LKK_auto_linter.sh MARKDOWN.md
+#
+
+# Explanation of options given to perl:
+# 
+# -i                                    Modifies your input file in-place (making a backup of
+#                                       the original). Handy to modify files without the {copy,
+#                                       delete-original, rename} process.
+#
+# -e                                    Allows you to provide the program as an argument rather
+#                                       than in a file. You don't want to have to create a script
+#                                       file for every little Perl one-liner.
+#
+#  0                                    Read the entire file (unlike line by line)
+#
+# -p                                    Places a printing loop around your command so
+#                                       that it acts on each line of standard input.
+
+if [ "$1" == "-h" ]; then
+    echo "Usage: `LKK_auto_linter` name_of_md_file_you_want_to_edit.md"
+    exit 0
+fi
+
+# Gives file input a better name and creates temp file
+FILE1=$1
+FILE2="${FILE1%.md}_temp.md"
+cp "$FILE1" "$FILE2"
+
+# Replace TAB with TWO SPACES 
+perl -i -0pe 's/\t/  /' $FILE2
+
+# Make sure the file ends with a blank line
+sed -i -e '$a\' $FILE2
+
+# Remove trailing whitespace if it exists
+sed -i -e 's/[[:space:]]*$//' $FILE2
+
+# Fixes YAML header (turns -- or ---- into ---) removes spacing before, adds blank line under
+perl -i -0pe 's/^\n*\h*---?-?((.|\n)*?)\h*---?-?\n*(.*)/---\1---\n\n\3/g' $FILE2
+
+# Corrects all titles with incorrect brackets {}
+# Titles should be formated: # Title {.word}
+perl -i -pe 's/^ ?(#+ .*[^\{])((\.\w*)|(([^\{]|\{\{+)(\.\w*)\}*)|(\{*(\.\w*)([^\}]|\}\}+)))$/\1\{\8\6\3\}/g' $FILE2
+
+# Converts every line starting with `` or ```` to ```
+perl -i -pe 's/^(\h*)(````|``)(\w*)$/\1```\3/g' $FILE2
+
+# Insert blank space above and below code blocks
+perl -i -0pe 's/(.)\n*(\h*```\w*\n[\s\S]*?```)\n*(.)/\1\n\n\2\n\n\3/g' $FILE2
+
+# Removes all the newlines before and after all titles
+# and inserts a newline before and after every title
+perl -i -0pe 's/(.)\n*(##* .*)\n*(.)/\1\n\n\2\n\n\3/g' $FILE2
+
+# Inserts an extra newline before all main titles
+perl -i -pe 's/(^#[^#].*)/\n\1/g' $FILE2
+
+# Autoformats main lists (- [ ]). Inserts space above
+perl -i -0pe 's/(.)\n+(- ?\[ ?\] ?)(.)/\1\n\n- \[ \] \3/g' $FILE2
+
+# Removes every instance of three consecutive newlines
+# perl -i -ane '$n=(@F==0) ? $n+1 : 0; print if $n<=2' $FILE2
+
+# This would overwrite the new file with the old if changes has been made
+if cmp -s "$FILE1" "$FILE2"
+then
+    # echo "The files are the same"
+    rm $FILE2
+else
+    echo "$FILE1"
+    mv $FILE2 $FILE1
+fi
+
+# Explenation of some of the regex
+#
+# s/^(\h*)(````|``)(\w*)$/\1```\3/g
+#
+# s                                   start search
+#   ^                                 start of the line
+#    (\h*)                            any number of horisontal space (save this in \1)
+#         (````|``)                   find 3 or 4 backticks
+#                  (\w*)              any number of words ([a-z]) (save this in \2)
+#                       $             end of the line
+#                        /            start the replacement for the first part
+#                         \1          insert content of capture group 1
+#                            ```      insert the correct number of backticks
+#                                \3   inserts the content of capture group 3
+#
+# \s                                  any number of whitespace
+# \S                                  any number of NON whitespace
+#  .                                  any character except linebreak
+#
+#
+#  +                                  modifier. One or more of the preceeding token. a+ would find one a or more
+#  ?                                  modifier. Zero or one of the preceeding token
+#  *                                  modifier. Any number of the preceeding token

--- a/linter/LKK_auto_linter.sh
+++ b/linter/LKK_auto_linter.sh
@@ -59,12 +59,20 @@ perl -i -pe 's/^(\h*)(````|``)(\w*)$/\1```\3/g' $FILE2
 # Insert blank space above and below code blocks
 perl -i -0pe 's/(.)\n*(\h*```\w*\n[\s\S]*?```)\n*(.)/\1\n\n\2\n\n\3/g' $FILE2
 
-# Removes all the newlines before and after all titles
-# and inserts a newline before and after every title
-perl -i -0pe 's/(.)\n*(##* .*)\n*(.)/\1\n\n\2\n\n\3/g' $FILE2
+# searches the line with "#" sign (all cases matches - Titles, SubTitles, etc),
+# takes all its upper empty lines
+# and converts them to the one empty line
+perl -i -0pe 's/\n+(#[^\n]+)/\n\n\1/g' $FILE2
 
-# Inserts an extra newline before all main titles
-perl -i -pe 's/(^#[^#].*)/\n\1/g' $FILE2
+# again, searches the line with "#" sign, take all its bottom empty lines
+# and converts them to the one empty line
+perl -i -0pe 's/(#[^\n]+)\n+/\1\n\n/g' $FILE2
+
+# searches the single "#" sign (Titles only),
+# takes all its upper newlines (at this moment only two of them are there,
+# because of previous substitutions)
+# and converts them to three newlines
+perl -i -0pe 's/\n+(#[^\n#]+)/\n\n\n\1/g' $FILE2
 
 # Autoformats main lists (- [ ]). Inserts space above
 perl -i -0pe 's/(.)\n+(- ?\[ ?\] ?)(.)/\1\n\n- \[ \] \3/g' $FILE2

--- a/linter/LKK_auto_linter_global.sh
+++ b/linter/LKK_auto_linter_global.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find ../src -name '*.md' -type f -exec ./LKK_auto_linter.sh {} \;


### PR DESCRIPTION
Poenget med filene er og automatisk linte filene i stil med stil guiden vi har. Den er godt kommentert for å forklare akkuratt hva som lintes. I utgangspunktet er linteren satt opp slik at den aldri vil linte en fil to ganger. Da scriptet oppretter en temp fil, linter denne også renamer temp fila dersom denne er ulik den opprinnelige. Scriptet har dog to mindre problemer, som jeg er usikker på hvordan jeg kan fikse.

* Filene i lista under bygges hver gang auto_linteren kjøres over oppgavesammlingen. 
* Den bryter og sammen dersom filene inneholder mellomrom 

Litt usikker på hvordan jeg kan fikse problemet med mellomrom, men i utgangspunktet skal jo ikke filnavn eller mappenavn inneholde mellomrom. Angående første forstår jeg ikke hvorfor den sier at filene har endret seg når de ikke har det?

Kjører man linteren to ganger over `src` forventes det at ingen filer skal lintes i andre omgang. Likevell så lintes følgende filer to ganger. 

```
../src/processing/README.md
../src/web/animasjon/animasjon.md
../src/web/tekststil/tekststil.md
../src/microbit/python_buttons/python_buttons_nb.md
../src/scratch/playlists/README.md
../src/scratch/reddverden/reddverden.md
../src/unity/README.md
../src/python/hemmelige_koder/hemmelige_koder.md
../src/python/tre_pa_rad_mot_datamaskinen/tre_pa_rad_mot_datamaskinen.md
../src/python/skilpaddefraktaler/skilpaddefraktaler.md
../src/python/skilpaddeskolen/skilpaddeskolen.md
../src/python/sprettball/sprettball.md
../src/python/lopende_strekmann/lopende_strekmann.md
../src/python/stjerner_og_galakser/stjerner_og_galakser.md
../src/python/regn_med_lokker/regn_med_lokker.md
../src/python/README.md
../src/python/tre_pa_rad/tre_pa_rad.md
../src/python/fargespill/fargespill.md
../src/python/skilpaddetekst/skilpaddetekst.md
../src/python/skilpadder_hele_veien/skilpadder_hele_veien.md
../src/python/tekst_abc/tekst_abc.md
```
