### PR TITLE
Scratch 2->3 spill lyden -> start lyden

### DIFF
--- a/src/scratch/bursdag_i_antarktis/bursdag_i_antarktis.md
+++ b/src/scratch/bursdag_i_antarktis/bursdag_i_antarktis.md
@@ -515,7 +515,7 @@ sette sammen tekst. Pass på at du skriver et mellomrom etter ordet `blir`!
 
   ```blocks
   når jeg mottar [Party v]
-  spill lyden [human beatbox1 v]
+  start lyden [human beatbox1 v]
   gjenta (20) ganger
       neste drakt
       vent (0.2) sekunder

--- a/src/scratch/bursdag_i_antarktis/bursdag_i_antarktis_nn.md
+++ b/src/scratch/bursdag_i_antarktis/bursdag_i_antarktis_nn.md
@@ -512,7 +512,7 @@ etter ordet `blir`!
 
   ```blocks
   når eg får meldinga [Party v]
-  spel lyden [human beatbox1 v]
+  start lyden [human beatbox1 v]
   gjenta (20) gongar
       neste drakt
       vent (0.2) sekund

--- a/src/scratch/felix_og_herbert/felix_og_herbert.md
+++ b/src/scratch/felix_og_herbert/felix_og_herbert.md
@@ -154,7 +154,7 @@ __Klikk på det grønne flagget.__
       neste drakt
       hvis <berører [Herbert v]?>
           send melding [Fanget! v]
-		  spill lyden [Mjau]
+		  start lyden [Mjau]
           si [Tok deg!] i (1) sekunder
           vent (1) sekunder
       slutt

--- a/src/scratch/flaksefugl/flaksefugl.md
+++ b/src/scratch/flaksefugl/flaksefugl.md
@@ -237,7 +237,7 @@ __Klikk det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   vent til <<berører [kant v]?> eller <berører [Rør v]?>>
-  spill lyden [screech v]
+  start lyden [screech v]
   si [Du tapte!]
   send melding [Tap v]
   stopp [andre skript i figuren v] :: control
@@ -281,7 +281,7 @@ __Klikk det grønne flagget.__
   når jeg starter som klon
   vent til <(x-posisjon) < ([x-posisjon v] av [Flakse v])>
   endre [poeng v] med (1)
-  spill lyden [bird v]
+  start lyden [bird v]
   ```
 
 ## Test prosjektet {.flag}

--- a/src/scratch/flaksefugl/flaksefugl_nn.md
+++ b/src/scratch/flaksefugl/flaksefugl_nn.md
@@ -229,7 +229,7 @@ leggje til nokre klossar som merkar om Flakse krasjar.*
   ```blocks
   når @greenFlag vert trykt på
   vent til <<rører [kant v]?> eller <rører [Røyr v]?>>
-  spel lyden [screech v]
+  start lyden [screech v]
   sei [Du tapte!]
   send meldinga [Tap v]
   stopp [andre skript i figuren v] :: control
@@ -271,7 +271,7 @@ __Klikk det grøne flagget.__
   når eg startar som klon
   vent til <(x-posisjon) < ([x-posisjon v] av [Flakse v])>
   endra [poeng v] med (1)
-  spel lyden [bird v]
+  start lyden [bird v]
   ```
 
 ## Test prosjektet {.flag}

--- a/src/scratch/fyrverkeri/fyrverkeri.md
+++ b/src/scratch/fyrverkeri/fyrverkeri.md
@@ -107,7 +107,7 @@ __Klikk på det grønne flagget.__
 
 - [ ] Endelig, prøv å få til det samme ved å bruke museknappen i stedet for
   mellomromstasten. For å gjøre dette kan vi pakke skriptet vårt inn i `for
-  alltid`{.blockcontrol}- og `hvis museknappen er nede`{.blockcontrol}-klosser.
+  alltid`{.blockcontrol}- og `hvis museknappen er trykket`{.blockcontrol}-klosser.
 
 - [ ] Flytt skriptet fra `når mellomrom trykkes`{.blockevents} til `når grønt
   flagg klikkes`{.blockevents}, slik at det blir seende slik ut:
@@ -116,7 +116,7 @@ __Klikk på det grønne flagget.__
   når grønt flagg klikkes
   skjul
   for alltid
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           vis
           gli (1) sekunder til x: (mus x) y: (mus y)
@@ -157,7 +157,7 @@ __Klikk på det grønne flagget.__
   når grønt flagg klikkes
   skjul
   for alltid
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           spill lyden [bang v]
           vis
@@ -175,7 +175,7 @@ __Klikk på det grønne flagget.__
   når grønt flagg klikkes
   skjul
   for alltid
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           spill lyden [bang v]
           vis
@@ -320,7 +320,7 @@ ble fanget inne i datamaskinene og ødela programmer.
   når grønt flagg klikkes
   skjul
   for alltid
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           spill lyden [bang v]
           vis

--- a/src/scratch/fyrverkeri/fyrverkeri.md
+++ b/src/scratch/fyrverkeri/fyrverkeri.md
@@ -159,7 +159,7 @@ __Klikk på det grønne flagget.__
   for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
-          spill lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1) sekunder til x: (mus x) y: (mus y)
           skjul
@@ -177,7 +177,7 @@ __Klikk på det grønne flagget.__
   for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
-          spill lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1) sekunder til x: (mus x) y: (mus y)
           skjul
@@ -322,7 +322,7 @@ ble fanget inne i datamaskinene og ødela programmer.
   for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
-          spill lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1.5) sekunder til x: (mus x) y: (mus y)
           skjul

--- a/src/scratch/fyrverkeri/fyrverkeri_nn.md
+++ b/src/scratch/fyrverkeri/fyrverkeri_nn.md
@@ -152,7 +152,7 @@ __Klikk på det grøne flagget.__
   for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
-          spel lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1) sekund til x: (mus x) y: (mus y)
           gøym
@@ -170,7 +170,7 @@ __Klikk på det grøne flagget.__
   for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
-          spel lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1) sekund til x: (mus x) y: (mus y)
           gøym
@@ -312,7 +312,7 @@ innsekt vart fanga inne i datamaskina og øydela programmet.
   for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
-          spel lyden [bang v]
+          start lyden [bang v]
           vis
           gli (1.5) sekund til x: (mus x) y: (mus y)
           gøym

--- a/src/scratch/jafsefisk/jafsefisk.md
+++ b/src/scratch/jafsefisk/jafsefisk.md
@@ -246,7 +246,7 @@ klikke med kjevene.
 
   ```blocks
   når jeg mottar [Du tok meg! v]
-  spill lyden [bite v]
+  start lyden [bite v]
   gjenta (2) ganger
       bytt drakt til [Shark2-a v]
       vent (0.3) sekunder

--- a/src/scratch/jafsefisk/jafsefisk_nn.md
+++ b/src/scratch/jafsefisk/jafsefisk_nn.md
@@ -248,7 +248,7 @@ klikke med kjevane.
 
   ```blocks
   når eg får meldinga [Du tok meg! v]
-  spel lyden [bubbles v]
+  start lyden [bubbles v]
   gjenta (2) gongar
       byt drakt til [Lukka munn v]
       vent (0.5) sekund

--- a/src/scratch/kingkong/kingkong.md
+++ b/src/scratch/kingkong/kingkong.md
@@ -133,7 +133,7 @@ står på venstre side av skyskraperen og en der han står på høyre side.
 Prøv gjerne de forskjellige tegneverktøyene på egen hånd. Vet du hva alle gjør?
 
 Legg merke til at nede i høyre hjørnet velger du mellom å jobbe med
-_punktgrafikk_ og _vektorgrafikk_. I punktgrafikk jobber vi med nettopp punktene
+_pikselgrafikk_ og _vektorgrafikk_. I pikselgrafikk jobber vi med nettopp punktene
 (også kalt pikslene) i bildet. Typisk vil du gjøre dette med bilder du laster
 ned fra nettet. Med vektorgrafikk kan vi jobbe med direkte med linjer og former.
 Mange av figurene i Scratchbiblioteket bruker dette, og det er ofte bedre når vi
@@ -153,7 +153,7 @@ Nå har vi tatt inn grafikken vi trenger. Det er på tide å begynne å programm
   ```blocks
   når grønt flagg klikkes
   sett størrelse til (200) %
-  legg foran
+  legg foran alt
   gå til x: (0) y: (-50)
   ```
 

--- a/src/scratch/norgestur/norgestur.md
+++ b/src/scratch/norgestur/norgestur.md
@@ -424,11 +424,11 @@ __Klikk på det grønne flagget.__
   `Effekter/rattle`, men du kan gjerne bruke en annen lyd.
 
 - [ ] Spill lyden når et sted blir funnet. Klikk `Skript`{.blocklightgrey}-fanen
-  og legg til en `spill lyden`{.blocksound}-kloss.
+  og legg til en `start lyden`{.blocksound}-kloss.
 
   ```blocks
   når jeg mottar [Fant sted v]
-  spill lyden [rattle v]
+  start lyden [rattle v]
   sett [gjennomsiktig v] effekt til (0)
   stemple avtrykk
   sett [gjennomsiktig v] effekt til (100)
@@ -715,4 +715,3 @@ Scratch. Klikk på `Se prosjektsiden` øverst til høyre. Du kommer da til en si
 hvor du kan beskrive prosjektet. En av boksene heter `Merknader og
 bidragsytere`. Her kan du nevne dem som opprinnelig har laget for eksempel
 kartet du bruker.
-

--- a/src/scratch/norgestur/norgestur_nn.md
+++ b/src/scratch/norgestur/norgestur_nn.md
@@ -419,12 +419,12 @@ __Klikk på det grøne flagget.__
   `Lyder`{.blocklightgrey}-fana og vel ein ny lyd frå biblioteket. Me brukar
   `Effekter/rattle`, men du kan gjerne bruke ein annan lyd.
 
-- [ ] Spel lyden når ein stad blir funne. Klikk `Skript`{.blocklightgrey}-fana
-  og legg til ein `spel lyden`{.blocksound}-kloss.
+- [ ] start lyden når ein stad blir funne. Klikk `Skript`{.blocklightgrey}-fana
+  og legg til ein `start lyden`{.blocksound}-kloss.
 
   ```blocks
   når eg får meldinga [Fann stad v]
-  spel lyden [rattle v]
+  start lyden [rattle v]
   set [gjennomsiktig v]-effekt til (0)
   lag avtrykk
   set [gjennomsiktig v]-effekt til (100)

--- a/src/scratch/orkenlop/orkenlop.md
+++ b/src/scratch/orkenlop/orkenlop.md
@@ -198,7 +198,7 @@ __Klikk på det grønne flagget.__
       gå (4) steg
       hvis <berører [kant v]?>
           sett [kappløp v] til [0]
-          spill lyden [Polly v]
+          start lyden [Polly v]
           si [Polly vinner!] i (3) sekunder
       slutt
   slutt
@@ -232,7 +232,7 @@ __Klikk på det grønne flagget.__
       gå (4) steg
       hvis <berører [kant v]?>
           sett [kappløp v] til [0]
-          spill lyden [Polly v]
+          start lyden [Polly v]
           si [Polly vinner! v] i (3) sekunder
           send melding [Avslutt v]
       slutt
@@ -303,10 +303,10 @@ hvis <<(kappløp) = [1]> og <(rakett_brukt) = [0]>>
     bytt drakt til [parrot-rakett v]
     sett [rakett_brukt v] til [1]
     gå (30) steg
-    spill lyden [motorcycle passing v]
+    start lyden [motorcycle passing v]
     hvis <berører [kant v]?>
         sett [kappløp v] til [0]
-        spill lyden [Polly v]
+        start lyden [Polly v]
         si [Polly vinner! v] i (3) sekunder
         send melding [Avslutt v]
     slutt
@@ -357,7 +357,7 @@ som at vi lager vår egen Scratch-kodekloss!
   definer ferdig
   hvis <berører [kant v]?>
       sett [kappløp v] til [0]
-      spill lyden [Polly v]
+      start lyden [Polly v]
       si [Polly vinner! v] i (3) sekunder
       send melding [Avslutt v]
 
@@ -371,7 +371,7 @@ som at vi lager vår egen Scratch-kodekloss!
       bytt drakt til [parrot-rakett v]
       sett [rakett_brukt v] til [1]
       gå (30) steg
-      spill lyden [motorcycle passing v]
+      start lyden [motorcycle passing v]
       ferdig
       bytt drakt til [parrot-a v]
   ```

--- a/src/scratch/orkenlop/orkenlop_nn.md
+++ b/src/scratch/orkenlop/orkenlop_nn.md
@@ -192,7 +192,7 @@ __Klikk på det grøne flagget.__
       gå (4) steg
       viss <rører [kant v]?>
           set [kappløp v] til [0]
-          spel lyden [Polly v]
+          start lyden [Polly v]
           sei [Polly vann!] i (3) sekund
       slutt
   slutt
@@ -225,7 +225,7 @@ __Klikk på det grøne flagget.__
       gå (4) steg
       viss <rører [kant v]?>
           set [kappløp v] til [0]
-          spel lyden [Polly v]
+          start lyden [Polly v]
           sei [Polly vann! v] i (3) sekund
           send meldinga [Avslutt v]
       slutt
@@ -295,10 +295,10 @@ viss <<(kappløp) = [1]> og <(rakett_brukt) = [0]>>
     bytt drakt til [parrot-rakett v]
     set [rakett_brukt v] til [1]
     gå (30) steg
-    spel lyden [motorcycle passing v]
+    start lyden [motorcycle passing v]
     viss <rører [kant v]?>
         set [kappløp v] til [0]
-        spel lyden [Polly v]
+        start lyden [Polly v]
         sei [Polly vann! v] i (3) sekund
         send meldinga [Avslutt v]
     slutt
@@ -349,7 +349,7 @@ Scratch-kodekloss!
   definer ferdig
   viss <rører [kant v]?>
       set [kappløp v] til [0]
-      spel lyden [Polly v]
+      start lyden [Polly v]
       sei [Polly vann! v] i (3) sekund
       send meldinga [Avslutt v]
 
@@ -363,7 +363,7 @@ Scratch-kodekloss!
       bytt drakt til [parrot-rakett v]
       set [rakett_brukt v] til [1]
       gå (30) steg
-      spel lyden [motorcycle passing v]
+      start lyden [motorcycle passing v]
       ferdig
       bytt drakt til [parrot-a v]
   ```

--- a/src/scratch/spokelsesjakten/spokelsesjakten.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten.md
@@ -161,7 +161,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når denne figuren klikkes
   skjul
-  spill lyden [fairydust v]
+  start lyden [fairydust v]
   ```
 
 ## Test prosjektet {.flag}
@@ -193,7 +193,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når denne figuren klikkes
   skjul
-  spill lyden [fairydust v]
+  start lyden [fairydust v]
   endre [Poeng v] med (1)
   ```
 

--- a/src/scratch/spokelsesjakten/spokelsesjakten_nn.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten_nn.md
@@ -156,7 +156,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når denne figuren vert trykt på
   gøym
-  spel lyden [fairydust v]
+  start lyden [fairydust v]
   ```
 
 ## Test prosjektet {.flag}
@@ -187,7 +187,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når denne figuren vert trykt på
   gøym
-  spel lyden [fairydust v]
+  start lyden [fairydust v]
   endra [Poeng v] med (1)
   ```
 

--- a/src/scratch/tegneprogram/tegneprogram.md
+++ b/src/scratch/tegneprogram/tegneprogram.md
@@ -76,7 +76,7 @@ interessert i nå er `penn på`{.blockpen} og `penn av`{.blockpen}.
   når grønt flagg klikkes
   for alltid
       gå til [musepeker v]
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           penn på
       ellers
           penn av
@@ -103,7 +103,7 @@ __Klikk på det grønne flagget.__
   slett
   for alltid
       gå til [musepeker v]
-      hvis <museknappen er nede?>
+      hvis <museknappen er trykket?>
           penn på
       ellers
           penn av
@@ -251,7 +251,7 @@ musepekeren er utenfor tavlas `x`- og `y`-koordinater, så virker ikke blyanten.
   for alltid
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
-          hvis <museknappen er nede?>
+          hvis <museknappen er trykket?>
               penn på
           ellers
               penn av
@@ -274,7 +274,7 @@ musepekeren er utenfor tavlas `x`- og `y`-koordinater, så virker ikke blyanten.
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
           vis
-          hvis <museknappen er nede?>
+          hvis <museknappen er trykket?>
               penn på
           ellers
               penn av
@@ -408,7 +408,7 @@ __Klikk på det grønne flagget.__
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
           vis
-          hvis <museknappen er nede?>
+          hvis <museknappen er trykket?>
               hvis <(stempelmodus) = [på]>
                   stemple avtrykk
               ellers


### PR DESCRIPTION
For de oppgavene der det er relevant. *Merk* ikke endret for blokken `spill lyden <x> til den er ferdig` (som fortsatt heter slik i Scratch 3)