### PR TITLE
Issue 943 add python linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ matrix:
       python: 3.7.4
       script:
         - pip install pathlib termcolor colorama
-        - python ./linter/LKK_linter.py ./src/
+        - cd linter
+        - python LKK_linter.py -r -l ../src/
     
     - language: node_js
       branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,40 @@
-language: node_js
+matrix:
+  include:
+    - language: python
+      python: 3.7.4
+      script:
+        - pip install pathlib
+        - python ./linter/LKK_linter.py
+    
+    - language: node_js
+      branches:
+        only:
+          - master
 
-python: 3.7.4
+      stages:
+        - name: deploy
+          if: branch = master AND fork = false AND type = push
 
-branches:
-  only:
-    - master
+      before_install:
+        - git clone --depth=1 --branch=master https://github.com/kodeklubben/codeclub-viewer.git ../codeclub-viewer
+        - cd ../codeclub-viewer
+        - nvm install
 
-stages:
-  - name: deploy
-    if: branch = master AND fork = false AND type = push
+      cache: yarn
 
-before_install:
-  - pip install pathlib
-  - python ./linter/LKK_linter.py
-  - git clone --depth=1 --branch=master https://github.com/kodeklubben/codeclub-viewer.git ../codeclub-viewer
-  - cd ../codeclub-viewer
-  - nvm install
+      script:
+        - yarn build:travis
 
-cache: yarn
-
-script:
-  - yarn build:travis
-
-# Deploy only runs for push builds (merges), never for PR builds:
-# https://docs.travis-ci.com/user/deployment#pull-requests
-deploy:
-  provider: pages
-  github-token: $GITHUB_TOKEN
-  skip-cleanup: true
-  keep-history: true
-  local-dir: ../codeclub-viewer/dist
-  repo: kodeklubben/kodeklubben.github.io
-  target-branch: master
-  fqdn: oppgaver.kidsakoder.no
-  on:
-    branch: master
+      # Deploy only runs for push builds (merges), never for PR builds:
+      # https://docs.travis-ci.com/user/deployment#pull-requests
+      deploy:
+        provider: pages
+        github-token: $GITHUB_TOKEN
+        skip-cleanup: true
+        keep-history: true
+        local-dir: ../codeclub-viewer/dist
+        repo: kodeklubben/kodeklubben.github.io
+        target-branch: master
+        fqdn: oppgaver.kidsakoder.no
+        on:
+          branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ stages:
     if: branch = master AND fork = false AND type = push
 
 before_install:
+  - pip install pathlib
   - python ./linter/LKK_linter.py
   - git clone --depth=1 --branch=master https://github.com/kodeklubben/codeclub-viewer.git ../codeclub-viewer
   - cd ../codeclub-viewer

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ matrix:
     - language: python
       python: 3.7.4
       script:
-        - pip install pathlib
-        - pip install termcolor
+        - pip install pathlib termcolor colorama
         - python ./linter/LKK_linter.py
     
     - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 
 python: 3.7.4
 
-script:
-  - python ./linter/LKK_linter.py
-
 branches:
   only:
     - master
@@ -14,6 +11,7 @@ stages:
     if: branch = master AND fork = false AND type = push
 
 before_install:
+  - python ./linter/LKK_linter.py
   - git clone --depth=1 --branch=master https://github.com/kodeklubben/codeclub-viewer.git ../codeclub-viewer
   - cd ../codeclub-viewer
   - nvm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 
+python: 3.7.4
+
 branches:
   only:
     - master
@@ -16,6 +18,7 @@ before_install:
 cache: yarn
 
 script:
+  - python ./linter/LKK_linter.py
   - yarn build:travis
 
 # Deploy only runs for push builds (merges), never for PR builds:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 
 python: 3.7.4
 
+script:
+  - python ./linter/LKK_linter.py
+
 branches:
   only:
     - master
@@ -18,7 +21,6 @@ before_install:
 cache: yarn
 
 script:
-  - python ./linter/LKK_linter.py
   - yarn build:travis
 
 # Deploy only runs for push builds (merges), never for PR builds:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       python: 3.7.4
       script:
         - pip install pathlib termcolor colorama
-        - python ./linter/LKK_linter.py
+        - python ./linter/LKK_linter.py ./src/
     
     - language: node_js
       branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
       python: 3.7.4
       script:
         - pip install pathlib
+        - pip install termcolor
         - python ./linter/LKK_linter.py
     
     - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ matrix:
   include:
     - language: python
       python: 3.7.4
+      before_install:
+        - cd linter
       script:
         - pip install pathlib termcolor colorama
-        - cd linter
-        - python LKK_linter.py -r -l ../src/
+        - python LKK_linter.py -r -l -md ../src/
     
     - language: node_js
       branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ matrix:
   include:
     - language: python
       python: 3.7.4
-      before_install:
+      before_script:
         - cd linter
       script:
         - pip install pathlib termcolor colorama
-        - python LKK_linter.py -r -l -md ../src/
+        - python LKK_linter.py -r -l ../src/
     
     - language: node_js
       branches:

--- a/linter/LKK_linter.py
+++ b/linter/LKK_linter.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import re
 import glob
 import os, sys

--- a/linter/linter_lib/linter_md.py
+++ b/linter/linter_lib/linter_md.py
@@ -252,7 +252,7 @@ def print_lines_with_errors(md_filepath, data, lines_with_errors):
 def main(md_files):
 
     for md_filepath in md_files:
-        with open(md_filepath, "r") as f:
+        with open(md_filepath, "r", encoding='utf8') as f:
             md_data = f.read()
 
         lines_with_errors = find_lines_with_errors(md_data, md_filepath)


### PR DESCRIPTION
Solves #943

Gjorde så travis kjører dette ved siden av sånn det var tidligere. Så man må sjekke manuelt linteren for feil før man pusher. Travis kommer aldri til å feile sånn det er nå.

Nå kjører tydeligvis bare linteren for yml, mens md linteren ikke kjøres? Vet ikke hvorfor, fordi det fungerer lokalt... Kanskje @Oisov har svaret? 

Linteren burde ikke sjekke oppgaver som er indexed: false