### PR TITLE
Formuleringer i oppgaven JafseFisk

### DIFF
--- a/src/scratch/jafsefisk/jafsefisk.md
+++ b/src/scratch/jafsefisk/jafsefisk.md
@@ -142,6 +142,7 @@ en liten stund senere.
 
   ```blocks
   når grønt flagg klikkes
+  vis
   gjenta for alltid
       gå (2) steg
       snu  @turnLeft (tilfeldig tall fra (-20) til (20)) grader
@@ -178,8 +179,7 @@ __Klikk på det grønne flagget.__
   y: (tilfeldig tall fra (-170) til (170))`{.b} som vi gir tilfeldige verdier
   for `x` og `y`.
 
-- [ ] For å sikre oss at byttedyret alltid er synlig når vi starter spillet legger
-  vi også til en 'vis'-kloss i starten av skriptet til byttedyret.
+Slik skal skriptet til byttedyret se ut:
 
   ```blocks
   når grønt flagg klikkes

--- a/src/scratch/jafsefisk/jafsefisk.md
+++ b/src/scratch/jafsefisk/jafsefisk.md
@@ -51,14 +51,14 @@ __Klikk på det grønne flagget.__
 - [ ] Flytt musepekeren rundt i sjøen. Følger fisken etter?
 
 - [ ] Hva skjer hvis du ikke flytter musepekeren og fisken når den igjen?
-
-- [ ] Hvordan ser den ut? Hvorfor gjør den dette?
+  Hvordan ser den ut? Hvorfor gjør den dette?
 
 ## Sjekkliste {.check}
 
-- [ ] Du kan stoppe JafseFisks maniske flipping hvis du sørger for at den bare
-  flytter seg når den ikke er for nær musepekeren (`avstand til [musepeker
-  v]`{.b} ligger i `Sansning`{.blocksensing}-kategorien).
+- [ ] Du kan stoppe flippingen til JafseFisk hvis du sørger for at den bare
+  flytter seg når den ikke er for nær
+  musepekeren (`avstand til [musepeker v]`{.b}
+  ligger i `Sansning`{.blocksensing}-kategorien).
 
   ```blocks
   når grønt flagg klikkes

--- a/src/scratch/jafsefisk/jafsefisk_nn.md
+++ b/src/scratch/jafsefisk/jafsefisk_nn.md
@@ -57,14 +57,14 @@ __Klikk på det grøne flagget.__
 - [ ] Flytt musepeikaren rundt i sjøen. Følgjer fisken etter?
 
 - [ ] Kva skjer viss du ikkje flyttar musepeikaren og fisken når den att?
-
-- [ ] Korleis ser den ut? Kvifor gjer den dette?
+  Korleis ser den ut? Kvifor gjer den dette?
 
 ## Sjekkliste {.check}
 
-- [ ] Du kan stoppe den maniske flippinga til Jafsefisk viss du syt for at den
-  berre flyttar seg når den ikkje er for nær musepeikaren (`avstand til
-  [musepeikar v]`{.b} ligg i `Sansing`{.blocksensing}-kategorien).
+- [ ] Du kan stoppe flippinga til Jafsefisk viss du syt for at den berre
+  flyttar seg når den ikkje er for nær musepeikaren
+  (`avstand til [musepeikar v]`{.b} ligg i
+  `Sansing`{.blocksensing}-kategorien).
 
   ```blocks
   når @greenFlag vert trykt på

--- a/src/scratch/jafsefisk/jafsefisk_nn.md
+++ b/src/scratch/jafsefisk/jafsefisk_nn.md
@@ -185,6 +185,8 @@ byttedyret er borti det kvite på tennene til Jafsefisk.*
   (tilfeldig tal frå (-170) til (170))`{.b} for å gi tilfeldige koordinatar for
   `x` og `y`.
 
+Slik skal skriptet til byttedyret sjå ut:
+
   ```blocks
   når @greenFlag vert trykt på
   for alltid

--- a/src/scratch/jafsefisk/jafsefisk_nn.md
+++ b/src/scratch/jafsefisk/jafsefisk_nn.md
@@ -148,6 +148,7 @@ lita stund seinare.
 
   ```blocks
   når @greenFlag vert trykt på
+  vis
   for alltid
       gå (2) steg
       snu @turnLeft (tilfeldig tal frå (-20) til (20)) gradar


### PR DESCRIPTION
Et løsningsforslag til sak #1217, der det ble påpekt følgende tre problemer med formuleringen i Scratch-oppgaven "JafseFisk" som flere deltakere på en Kodeklubb ble forvirret over. Commitene i denne PR-en er rent kosmetiske, og kan testes ved å bygge og kjøre nettsiden lokalt.

1) **Linje 55 "Hvordan ser den ut? Hvorfor gjør den dette?" Dette er et retorisk spørsmål. Bør ikke ha checkbox.** Fjernet den tredje sjekkboksen og la teksten inn på det andre punktet.
2) **Linje 59 Barna har problemer med "manisk", foreslår å bare ha "flipping".** Fjernet ordet ''manisk'' i bokmålsversjonen.
3) **Ganske mange av barna hadde mistet byttedyret lenge før linje 181. Foreslår å legge inn "vis" kloss allerede rundt linje 142.** La til vis-blokken lenger opp i oppgaveteksten.
