### PR TITLE
Brikken heter "gjenta for alltid" ikke "for alltid" - den har byttet navn det siste året en gang

### DIFF
--- a/src/scratch/3d_flakser_del1/3d_flakser_del1_nn.md
+++ b/src/scratch/3d_flakser_del1/3d_flakser_del1_nn.md
@@ -36,7 +36,7 @@ inni kvarandre, fylt med ein farge i mellom.
     ```blocks
         når eg får meldinga [Nytt spel v]
         gøym
-        for alltid
+        gjenta for alltid
             lag klon av [meg v]
             vent (1) sekund
         slutt
@@ -172,7 +172,7 @@ flaggermus-figuren. Kall den __Flakse__.
         når eg får meldinga [Nytt spel v]
         set [x v] til [0]
         set [y v] til [0]
-        for alltid
+        gjenta for alltid
             viss <tasten [pil høgre v] er trykt>
                 endra [x v] med (10)
                 vent (0.05) sekund

--- a/src/scratch/3d_flakser_del2/3d_flakser_del2.md
+++ b/src/scratch/3d_flakser_del2/3d_flakser_del2.md
@@ -41,8 +41,8 @@ eller siden bakken. Dette gjør vi med en ny figur som vi kaller `bakken`.
 - [ ] Nå vil vi at bakken skal følge med Flakse, det vil si: når Flakse er høyt
   oppe (`y`{.blockdata} er stor) så skal bakken gå nedover, og når Flakse er
   langt nede så er bakken tilsvarende høyt oppe. Hvis Flakse berører bakken skal
-  spilleren tape. Vi legger til følgende `for alltid`{.blockcontrol}-løkke i
-  skriptet til bakken,
+  spilleren tape. Vi legger til følgende `gjenta for
+  alltid`{.blockcontrol}-løkke i skriptet til bakken,
 
   ```blocks
   gjenta for alltid

--- a/src/scratch/3d_flakser_del2/3d_flakser_del2.md
+++ b/src/scratch/3d_flakser_del2/3d_flakser_del2.md
@@ -42,7 +42,7 @@ eller siden bakken. Dette gjør vi med en ny figur som vi kaller `bakken`.
   oppe (`y`{.blockdata} er stor) så skal bakken gå nedover, og når Flakse er
   langt nede så er bakken tilsvarende høyt oppe. Hvis Flakse berører bakken skal
   spilleren tape. Vi legger til følgende `gjenta for
-  alltid`{.blockcontrol}-løkke i skriptet til bakken,
+  alltid`{.blockcontrol}-løkke i skriptet til bakken:
 
   ```blocks
   gjenta for alltid

--- a/src/scratch/3d_flakser_del2/3d_flakser_del2_nn.md
+++ b/src/scratch/3d_flakser_del2/3d_flakser_del2_nn.md
@@ -41,10 +41,10 @@ før eller seinare. Dette gjer me med ein ny figur som me kallar `bakken`.
   er høgt oppe (`y`{.blockdata} er stor) så går bakken nedover, og når Flakse
   er langt nede skal bakken vere tilsvarande høgt oppe. Viss Flakse kjem
   borti bakken skal spelaren tape. Me legg til følgande
-  `for alltid`{.blockcontrol}-løkke i skriptet til bakken:
+  `gjenta for alltid`{.blockcontrol}-løkke i skriptet til bakken:
 
   ```blocks
-  for alltid
+  gjenta for alltid
       set y til ((20) - (y))
       viss <rører [Flakse v]>
           sei [du tapte!] i (2) sekund
@@ -112,7 +112,7 @@ figuren, slik at den flaksar med vengjene når me trykkar mellomromtasten.
 
   ```blocks
   når eg får meldinga [Nytt spel v]
-  for alltid
+  gjenta for alltid
       gjenta til <(flaks) = [0]>
           endra [flaks v] med (-1)
           viss <(løft) < [5]>

--- a/src/scratch/README.md
+++ b/src/scratch/README.md
@@ -40,14 +40,13 @@ Hele kodesnutter skrives som et eget avsnitt på følgende måte:
 <pre>
 ```blocks
 når grønt flagg trykkes
-for alltid
+gjenta for alltid
 pek mot [musepekeren v]
 slutt
 ```
 </pre>
 
-Hvis du vil referere til enkeltblokker i teksten kan det gjøres slik: `` `for
-alltid`{.b}``. I tillegg er fargene for kategoriene tilgjengenlig:
+Hvis du vil referere til enkeltblokker i teksten kan det gjøres slik: `` `gjenta for alltid`{.b}``. I tillegg er fargene for kategoriene tilgjengenlig:
 
 - `` `Bevegelse`{.blockmotion}``
 

--- a/src/scratch/asteroids/asteroids.md
+++ b/src/scratch/asteroids/asteroids.md
@@ -78,7 +78,7 @@ prosjekter. Vi vil derfor først kopiere romskipet vi laget i Lunar Lander.
 
 - [ ] Vi skal gjøre en liten forandring i hvordan romskipet oppfører seg.
   Asteroids foregår langt ute i rommet hvor det ikke er noen merkbar
-  tyngdekraft. Slett derfor klossen som modellerer tyngdekraften i `for
+  tyngdekraft. Slett derfor klossen som modellerer tyngdekraften i `gjenta for
   alltid`{.blockcontrol}-løkken din, `endre [fartY v] med (-0.01)`{.b}.
 
 - [ ] Vi skal også gjøre en litt større endring i spillet. Vi vil at

--- a/src/scratch/asteroids/asteroids_nn.md
+++ b/src/scratch/asteroids/asteroids_nn.md
@@ -80,7 +80,7 @@ fly romskipet rundt omkring?
 
 - [ ] Me skal gjera ein liten forandring i korleis romskipet oppfører seg.
 Asteroids foregår langt ute i rommet der det ikkje er noko merkbar tyngdekraft.
-Slett derfor klossen som modellerar tyngdekrafta i `for
+Slett derfor klossen som modellerar tyngdekrafta i `gjenta for
 alltid`{.blockcontrol}-løkka di, `endra [fartY v] med (-0.01)`{.b}.
 
 - [ ] Me skal og gjera ein litt større endring i spelet. Me vil at verdsrommet
@@ -94,7 +94,7 @@ skjermen på den eine sida skal det dukka opp på andre sida av skjermen.
 
   ```blocks
       når eg får meldinga [Nytt spel v]
-      for alltid
+      gjenta for alltid
           viss <(x-posisjon) < (-235)>
               endra x med (470)
           slutt
@@ -127,10 +127,10 @@ stor. Legg også på ein kloss for å `gøyme`{.blocklooks} figuren.
 koden som lagar ein ny skotklone når du trykkjer mellomromtasten:
 
   Lag eit skript på skot-figuren som starter på `Nytt spel`-meldingen.
-  Skriptet kan bestå av ein `for alltid`{.blockcontrol}-løkke, der du testar om
-  mellomromtasten er trykka. Dersom eit skot skal avfyrast kan du først la
-  skotet `gå til`{.blockmotion} romskipet og deretter peike i same retning som
-  romskipet. Dette siste kan du gjera med ein kombinasjon av `peik i
+  Skriptet kan bestå av ein `gjenta for alltid`{.blockcontrol}-løkke, der du
+  testar om mellomromtasten er trykka. Dersom eit skot skal avfyrast kan du
+  først la skotet `gå til`{.blockmotion} romskipet og deretter peike i same
+  retning som romskipet. Dette siste kan du gjera med ein kombinasjon av `peik i
   retning`{.blockmotion}, `retning av`{.blocksensing} og
   `vend`{.blockmotion}-klosser. Til slutt kan du `lage ein klon`{.blockcontrol}
   av figuren.

--- a/src/scratch/astrokatt/astrokatt_nn.md
+++ b/src/scratch/astrokatt/astrokatt_nn.md
@@ -65,7 +65,7 @@ Me begynner prosjektet vårt med å få katten til å fly!
 
     ```blocks
         når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             gå (10) steg
             snu @turnRight (15) gradar
         slutt
@@ -94,7 +94,7 @@ __Klikk på det!__
 
     ```blocks
         når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             viss <tasten [pil høgre v] er trykt?>
                 snu @turnRight (5) gradar
             slutt
@@ -163,7 +163,7 @@ realistisk.
 
     ```blocks
         når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             snu @turnRight (1) gradar
         slutt
     ```
@@ -173,12 +173,12 @@ realistisk.
       den kjem jordkloden.
 
   Klikk på katten i figurlista. Legg `set storleik til`{.blocklooks} nederst i
-  `for alltid`{.blockcontrol}-løkka, slik at størrelsen på katten er avhengig av
+  `gjenta for alltid`{.blockcontrol}-løkka, slik at størrelsen på katten er avhengig av
   avstanden til jordkloden:
 
     ```blocks
         når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             viss <tasten [pil høgre v] er trykt?>
                 snu @turnRight (5) gradar
             slutt
@@ -246,7 +246,7 @@ la astrokatten vår bli påverka av gravitasjonen og.
     ```blocks
         når @greenFlag vert trykt på
         gå til x: (-200) y: (150)
-        for alltid
+        gjenta for alltid
             peik mot [Earth v]
             gå (1) steg
         slutt
@@ -257,9 +257,9 @@ la astrokatten vår bli påverka av gravitasjonen og.
 
 - [ ] MEN, me har eit problem: Me kan ikkje lengre styra katten! Kva har skjedd?
 
-    I det nye skriptet seier me at katten `for alltid`{.blockcontrol} skal
-    `peike mot`{.blockmotion} jordkloden. Då hjelper det jo ikkje at me i det
-    andre skriptet seier at katten skal snu seg.
+    I det nye skriptet seier me at katten `gjenta for alltid`{.blockcontrol}
+    skal `peike mot`{.blockmotion} jordkloden. Då hjelper det jo ikkje at me i
+    det andre skriptet seier at katten skal snu seg.
 
 - [ ] Det er ingen kommando i Scratch for å flytta ein figur mot ein annan.
       Derfor må me peika katten mot jordkloden og deretter flytta den. Men me
@@ -276,7 +276,7 @@ la astrokatten vår bli påverka av gravitasjonen og.
     ```blocks
         når @greenFlag vert trykt på
         gå til x: (-200) y: (150)
-        for alltid
+        gjenta for alltid
             set [katteretning v] til (retning)
             peik mot [Earth v]
             gå (1) steg

--- a/src/scratch/data_navn/data_navn.md
+++ b/src/scratch/data_navn/data_navn.md
@@ -143,7 +143,7 @@ __Klikk på koden din.__
   kan gjøre det på akkurat samme måte som for jentenavn. Legg den nye
   hvis-testen under den du allerede har.
 
-- [ ] Legg til en `for alltid`{.b}-løkke rundt hele koden din. På den måten vil
+- [ ] Legg til en `gjenta for alltid`{.b}-løkke rundt hele koden din. På den måten vil
   katten stadig spørre deg om nye navn.
 
 - [ ] Legg også en `når grønt flagg klikkes`{.b}-kloss på toppen av koden din, slik

--- a/src/scratch/data_navn/data_navn_nn.md
+++ b/src/scratch/data_navn/data_navn_nn.md
@@ -138,7 +138,7 @@ __Klikk på koden din.__
   sjølv. Du kan gjere det på akkurat same måte som for jentenamn. Legg den nye
   viss-testen under den du allereie har.
 
-- [ ] Legg til ei `for alltid`{.b}-løkke rundt heile koden din. Det gjer at
+- [ ] Legg til ei `gjenta for alltid`{.b}-løkke rundt heile koden din. Det gjer at
   katten stadig vil spørje deg om nye namn.
 
 - [ ] Legg ein `når @greenFlag vert trykt på`{.b}-kloss på toppen av koden din,

--- a/src/scratch/donkey_kong/donkey_kong.md
+++ b/src/scratch/donkey_kong/donkey_kong.md
@@ -215,7 +215,7 @@ dem.
   `skjules`{.blocklooks} når det grønne flagget klikkes.
 
 - [ ] Nå skal vi skrive koden på Donkey Kong. Den blir ganske enkel. Etter at
-  `Donkey Kong` mottar `nytt spill` kan du la han gå inn i en `for
+  `Donkey Kong` mottar `nytt spill` kan du la han gå inn i en `gjenta for
   alltid`{.blockcontrol}-løkke hvor han `lager klon av Ildkule`{.blockcontrol}
   og deretter `venter 3 sekunder`{.blockcontrol}.
 

--- a/src/scratch/donkey_kong/donkey_kong_nn.md
+++ b/src/scratch/donkey_kong/donkey_kong_nn.md
@@ -80,7 +80,7 @@ og særskilt korleis me får den til å hoppe og falle på ein truverdig måte.
   ```blocks
   når eg får meldinga [Nytt spel v]
   gå til x: (-150) y: (-100)
-  for alltid  // hovudløkka
+  gjenta for alltid  // hovudløkka
       set [fartX v] til ((0.8) * (fartX))  // farta bremsast
       endra [fartY v] med (-0.5)  // gravitasjon, figuren fell
       viss <rører fargen [#0000ff]>  // figuren står på plattforma
@@ -209,7 +209,7 @@ rullande ildkuler mot oss.*
   når du klikkar på det grøne flagget.
 
 - [ ] No skal me skrive koden på Donkey Kong. Den blir ganske enkel. Etter
-  at `Donkey Kong` mottek `Nytt spel` kan du la han gå inn i ei `for
+  at `Donkey Kong` mottek `Nytt spel` kan du la han gå inn i ei `gjenta for
   alltid`{.blockcontrol}-løkke der han `lagar klon av
   Ildkule`{.blockcontrol} og så `ventar 3 sekund`{.blockcontrol}.
 

--- a/src/scratch/enarmet_banditt/enarmet_banditt_nn.md
+++ b/src/scratch/enarmet_banditt/enarmet_banditt_nn.md
@@ -44,7 +44,7 @@ figurane stoppar ein etter ein, og målet er at alle skal vere like.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       neste drakt
       vent (0.5) sekund
   slutt
@@ -86,7 +86,7 @@ vere ei praktisk løysing.
   ```blocks
   når @greenFlag vert trykt på
   set [stoppa v] til [0]
-  for alltid
+  gjenta for alltid
       neste drakt
       vent (0.5) sekund
   slutt
@@ -108,7 +108,7 @@ vere ei praktisk løysing.
   ```blocks
   når @greenFlag vert trykt på
   set [stoppa v] til [0]
-  for alltid
+  gjenta for alltid
       viss <(stoppa) = [0]>
           neste drakt
           vent (0.5) sekund
@@ -171,14 +171,14 @@ blir meir morosamt (og vanskelegare) viss dei endrar drakt meir tilfeldig.
   `byt drakt til`{.blocklooks}-kloss med `tilfeldig tal frå 1 til
   3`{.blockoperators}. Den vel eit tilfeldig draktnummer.
 
-- [ ] Me kan bruke den same klossen i `for alltid`{.blockcontrol}-løkka slik at
-  figuren byttar til ei tilfeldig drakt kvar gong.
+- [ ] Me kan bruke den same klossen i `gjenta for alltid`{.blockcontrol}-løkka
+  slik at figuren byttar til ei tilfeldig drakt kvar gong.
 
   ```blocks
   når @greenFlag vert trykt på
   set [stoppa v] til [0]
   byt drakt til (tilfeldig tal frå (1) til (3))
-  for alltid
+  gjenta for alltid
       viss <(stoppa) = [0]>
           byt drakt til (tilfeldig tal frå (1) til (3))
           vent (0.5) sekund

--- a/src/scratch/felix_og_herbert/felix_og_herbert_nn.md
+++ b/src/scratch/felix_og_herbert/felix_og_herbert_nn.md
@@ -40,7 +40,7 @@ din ned.
 
     ```blocks
         Når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             peik mot [musepeikar v]
             gå (10) steg
             neste drakt
@@ -90,7 +90,7 @@ Viss du ikkje har brukar kan du ikkje lagre, berre fortsett til steg 2.
 
     ```blocks
         Når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             gå til [musepeikar v]
             peik mot [Felix v]
         slutt
@@ -115,7 +115,7 @@ __Klikk på det grøne flaget.__
 
     ```blocks
         Når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             peik mot [musepeikar v]
             gå (10) steg
             neste drakt
@@ -145,7 +145,7 @@ spøkelse når han vert fanga.*
 
     ```blocks
         Når @greenFlag vert trykt på
-        for alltid
+        gjenta for alltid
             peik mot [musepeikar v]
             gå (10) steg
             neste drakt
@@ -214,7 +214,7 @@ sekund. Hvis Felix fangar Herbert, minker me poengsummen med ti.*
     ```blocks
         Når @greenFlag vert trykt på
         sett [Poeng v] til (0)
-        for alltid
+        gjenta for alltid
             vent (1) sekund
             endra [Poeng v] med (1)
         når eg får meldinga [Fanga! v]

--- a/src/scratch/flagg/flagg_nn.md
+++ b/src/scratch/flagg/flagg_nn.md
@@ -40,7 +40,7 @@ No skal me bruke dette til å teikne sirklar!
   ```blocks
   når @greenFlag vert trykt på
   avgrens rotering til [ikkje roter v]
-  for alltid
+  gjenta for alltid
       set x til ((100) * ([cos v] av (retning)))
       set y til ((100) * ([sin v] av (retning)))
       snu @turnLeft (5) gradar
@@ -88,7 +88,7 @@ Til no har me berre teikna ein sirkel midt på skjermen. No skal me flytte den!
   avgrens rotering til [ikkje roter v]
   set [sentrumX v] til [-100]
   set [sentrumY v] til [50]
-  for alltid
+  gjenta for alltid
       set x til ((sentrumX) + ((100) * ([cos v] av (retning)))
       set y til ((sentrumY) + ((100) * ([sin v] av (retning)))
       snu @turnLeft (5) gradar
@@ -136,7 +136,7 @@ No skal me prøve å få mange figurar til å gå i sirkel samstundes.
   slutt
 
   når eg startar som klon
-  for alltid
+  gjeta for alltid
       set x til ((sentrumX) + ((radius) * ([cos v] av (retning)))
       set y til ((sentrumY) + ((radius) * ([sin v] av (retning)))
       snu @turnLeft (5) gradar
@@ -189,7 +189,7 @@ flagg.
 
   ```blocks
   når eg får meldinga [flagre v]
-  for alltid
+  gjenta for alltid
       set x til ((sentrumX) + ((radius) * ([cos v] av (retning)))
       set y til ((sentrumY) + ((radius) * ([sin v] av (retning)))
       snu @turnLeft (5) gradar
@@ -241,7 +241,7 @@ No skal me teikne flagget med ulike fargar.
   byt drakt til (bokstav (nummer) i (flagg))
   ```
 
-  øvst i `for alltid`{.blockcontrol}-løkka i `flagre`-skriptet.
+  øvst i `gjenta for alltid`{.blockcontrol}-løkka i `flagre`-skriptet.
 
 - [ ] Køyr programmet ditt. Den venstre delen av flagget ditt skal ha fått
   fargane til det norske flagget. For å farge heilt flagget må me gi mange

--- a/src/scratch/flaksefugl/flaksefugl_nn.md
+++ b/src/scratch/flaksefugl/flaksefugl_nn.md
@@ -34,7 +34,7 @@ Flakse flygande og prøve å styre mellom røra.
   ```blocks
   når @greenFlag vert trykt på
   gå til x: (-50) y: (0)
-  for alltid
+  gjenta for alltid
       endra y med (-3)
   slutt
   ```
@@ -104,7 +104,7 @@ gjere.*
   når @greenFlag vert trykt på
   set [flaks v] til [0]
   byt drakt til [Venger opp v]
-  for alltid
+  gjenta for alltid
       gjenta til <(flaks) = [0]>
           endra [flaks v] med (-1)
           byt drakt til [Venger ned v]
@@ -179,7 +179,7 @@ ei hinderløype for Flakse.*
   når @greenFlag vert trykt på
   gøym
   set storleik til (200)%
-  for alltid
+  gjenta for alltid
       lag klon av [meg v]
       vent (2) sekund
   slutt
@@ -300,7 +300,7 @@ Me skal prøve å etterlikne denne måten å dette på.
   når @greenFlag vert trykt på
   set [løft v] til [0]
   gå til x: (-50) y: (0)
-  for alltid
+  gjenta for alltid
       endra y med (løft)
       endra [løft v] med (-0.2)
   slutt
@@ -312,7 +312,7 @@ Me skal prøve å etterlikne denne måten å dette på.
   når @greenFlag vert trykt på
   set [flaks v] til [0]
   byt drakt til [Venger opp v]
-  for alltid
+  gjenta for alltid
       gjenta til <(flaks) = [0]>
           endra [flaks v] med (-1)
           byt drakt til [Venger ned v]
@@ -343,7 +343,7 @@ Når spelaren tapar vil me at Flakse skal dette ned og ut av skjermen.
 
   ```blocks
   når eg får meldinga [Fall v]
-  for alltid
+  gjenta for alltid
       snu @turnRight (5) gradar
   slutt
 

--- a/src/scratch/fyrverkeri/fyrverkeri.md
+++ b/src/scratch/fyrverkeri/fyrverkeri.md
@@ -106,8 +106,8 @@ __Klikk på det grønne flagget.__
 ## Sjekkliste {.check}
 
 - [ ] Endelig, prøv å få til det samme ved å bruke museknappen i stedet for
-  mellomromstasten. For å gjøre dette kan vi pakke skriptet vårt inn i `for
-  alltid`{.blockcontrol}- og `hvis museknappen er trykket`{.blockcontrol}-klosser.
+  mellomromstasten. For å gjøre dette kan vi pakke skriptet vårt inn i `gjenta
+  for alltid`{.blockcontrol}- og `hvis museknappen er trykket`{.blockcontrol}-klosser.
 
 - [ ] Flytt skriptet fra `når mellomrom trykkes`{.blockevents} til `når grønt
   flagg klikkes`{.blockevents}, slik at det blir seende slik ut:
@@ -115,7 +115,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   skjul
-  for alltid
+  gjenta for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           vis
@@ -156,7 +156,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   skjul
-  for alltid
+  gjenta for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]
@@ -174,7 +174,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   skjul
-  for alltid
+  gjenta for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]
@@ -319,7 +319,7 @@ ble fanget inne i datamaskinene og ødela programmer.
   ```blocks
   når grønt flagg klikkes
   skjul
-  for alltid
+  gjenta for alltid
       hvis <museknappen er trykket?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]

--- a/src/scratch/fyrverkeri/fyrverkeri_nn.md
+++ b/src/scratch/fyrverkeri/fyrverkeri_nn.md
@@ -101,8 +101,8 @@ __Klikk på det grøne flagget.__
 
 - [ ] Prøv å få til det det same ved å bruke museknappen i staden for
   mellomromtasten. For å gjere det kan me pakke skriptet vårt inn i
-  `for alltid`{.blockcontrol}- og `viss museknappen er trykt`{.blockcontrol}-
-  klossar.
+  `gjenta for alltid`{.blockcontrol}- og `viss museknappen er
+  trykt`{.blockcontrol}-klossar.
 
 - [ ] Flytt skriptet frå `når mellomrom vert trykt`{.blockevents} til `når
   @greenFlag vert trykt på`{.blockevents}, så det ser slik ut:
@@ -110,7 +110,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   gøym
-  for alltid
+  gjenta for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
           vis
@@ -149,7 +149,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   gøym
-  for alltid
+  gjenta for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]
@@ -167,7 +167,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   gøym
-  for alltid
+  gjenta for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]
@@ -309,7 +309,7 @@ innsekt vart fanga inne i datamaskina og øydela programmet.
   ```blocks
   når @greenFlag vert trykt på
   gøym
-  for alltid
+  gjenta for alltid
       viss <museknappen er trykt?>
           gå til x: (mus x) y: (-200)
           start lyden [bang v]

--- a/src/scratch/halloweenimasjon/halloweenimasjon_nn.md
+++ b/src/scratch/halloweenimasjon/halloweenimasjon_nn.md
@@ -227,11 +227,11 @@ bakgrunnen og å starte spøkelsesanimasjonen.
 
 ## Sjekkliste {.check}
 
-- [ ] Me startar med å lage ei `for alltid`{.blockcontrol}-løkke på scena som
-  sender meldingane
+- [ ] Me startar med å lage ei `gjenta for alltid`{.blockcontrol}-løkke på
+  scena som sender meldingane
 
   ```blocks
-  for alltid
+  gjenta for alltid
       send meldinga [Animer spøkelse v] og vent
       send meldinga [Animer flaggermus v] og vent
   slutt
@@ -244,7 +244,7 @@ bakgrunnen og å starte spøkelsesanimasjonen.
   til eit par `vent`{.blockcontrol}-klossar i skriptet.
 
   ```blocks
-  for alltid
+  gjenta for alltid
       send meldinga [Animer spøkelse v] og vent
       vent (1) sekund
       send meldinga [Animer flaggermus v] og vent
@@ -257,7 +257,7 @@ bakgrunnen og å starte spøkelsesanimasjonen.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       send meldinga [Animer spøkelse v] og vent
       vent (1) sekund
       send meldinga [Animer flaggermus v] og vent
@@ -353,7 +353,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       send meldinga [Animer spøkelse v] og vent
       vent (1) sekund
       send meldinga [Animer flaggermus v] og vent

--- a/src/scratch/hoppehelt/hoppehelt_nn.md
+++ b/src/scratch/hoppehelt/hoppehelt_nn.md
@@ -63,7 +63,7 @@ blir brukt til programmering i Scratch. Me skal også sjå på klonar av klonar!
   ```blocks
   når eg får meldinga [Nytt spel v]
   gå til x: (210) y: (-120)
-  for alltid
+  gjenta for alltid
       endra [sprett v] med (-1)
       viss <rører fargen [#00cc00] ?>
           neste drakt
@@ -136,7 +136,7 @@ __Klikk på det grøne flagget.__
 ## Sjekkliste {.check}
 
 - [ ] Me vil at spelet skal stoppe når helten spring inn i ein boks. Gå til
-  `Helt 1`. Bytt ut `for alltid`{.blockcontrol}-løkka med ei `gjenta
+  `Helt 1`. Bytt ut `gjenta for alltid`{.blockcontrol}-løkka med ei `gjenta
   til`{.blockcontrol}-løkke som du gjentek til helten kjem borti `Boks`.
 
 - [ ] Etter den nye `gjenta til`{.blockcontrol}-løkka kan du sende ut ei ny

--- a/src/scratch/hvor_i_all_verden_del1/hvor_i_all_verden_del1_nn.md
+++ b/src/scratch/hvor_i_all_verden_del1/hvor_i_all_verden_del1_nn.md
@@ -73,7 +73,7 @@ med piltastane.*
   når eg får meldinga [Nytt spel v]
   gå til x: (0) y: (0)
   vis
-  for alltid
+  gjenta for alltid
       viss <tasten [pil høgre v] er trykt?>
           peik i retning (90 v)
           gå (hastigheit) steg

--- a/src/scratch/hvor_i_all_verden_del2/hvor_i_all_verden_del2_nn.md
+++ b/src/scratch/hvor_i_all_verden_del2/hvor_i_all_verden_del2_nn.md
@@ -157,7 +157,7 @@ kartet flytte seg nedover viss me vil at helikopteret skal fly oppover.
   ```blocks
   når eg får meldinga [Nytt spel v]
   vis
-  for alltid
+  gjenta for alltid
       gå til x: ((0) - (X)) y: ((0) - (Y))
   slutt
   ```
@@ -215,7 +215,7 @@ helikopteret ikkje kan flyge ut av kartet?
 
   ```blocks
   når eg får meldinga [Nytt spel v]
-  for alltid
+  gjenta for alltid
       gå til x: ((stadX) - (X)) y: ((stadY) - (Y))
   slutt
   ```

--- a/src/scratch/intro_til_programmering.md
+++ b/src/scratch/intro_til_programmering.md
@@ -59,20 +59,22 @@ holde styr på poeng, tid, tur, hastighet, vinner og mye mer.
 
 ## Løkker
 
-Veldig ofte i programmer har vi bruk for å gjøre noen instrukser flere ganger.
-La oss si vi vil at datamaskinen vår skal lage (data)pannekaker. Da vil vi at
-datamaskinen skal hente et egg, knuse det i bollen og røre rundt. Og vi vil at
-den skal gjøre det mange ganger. Da kan vi bruke det som heter en __løkke__ for
-å be den gjøre den samme oppgaven (blande inn et egg) så mange ganger vi måtte
+Veldig ofte i programmer har vi bruk for å gjøre noen instrukser flere
+ganger.  La oss si vi vil at datamaskinen vår skal lage
+(data)pannekaker. Da vil vi at datamaskinen skal hente et egg, knuse
+det i bollen og røre rundt. Og vi vil at den skal gjøre det mange
+ganger. Da kan vi bruke det som heter en __løkke__ for å be den gjøre
+den samme oppgaven (blande inn et egg) så mange ganger vi måtte
 ønske. I Scratch så finner vi alle løkkene under
-`Styring`{.blockyellow}-kategorien. Hvis vi vil at noe skal gjentas et bestemt
-antall ganger, så bruker vi en `gjenta (10) ganger`{.blockyellow}-blokk. Du
-legger kanskje merke til at denne blokken ikke er som alle andre blokker? Den
-har nemlig et lite hulrom hvor du kan knepse inn de instruksene du vil skal
-gjentas. En anne viktig type løkke heter `for alltid`{.blockyellow}. I stedet
-for å gjenta noe et bestemt antall ganger, så gjentar den noe *i evigheten*. Da
-gjelder det å være forsiktig så man ikke ender opp med en uendelig stor
-eggerøre!
+`Styring`{.blockyellow}-kategorien. Hvis vi vil at noe skal gjentas et
+bestemt antall ganger, så bruker vi en `gjenta (10)
+ganger`{.blockyellow}-blokk. Du legger kanskje merke til at denne
+blokken ikke er som alle andre blokker? Den har nemlig et lite hulrom
+hvor du kan knepse inn de instruksene du vil skal gjentas. En anne
+viktig type løkke heter `gjenta for alltid`{.blockyellow}. I stedet
+for å gjenta noe et bestemt antall ganger, så gjentar den noe *i
+evigheten*. Da gjelder det å være forsiktig så man ikke ender opp med
+en uendelig stor eggerøre!
 
 ## Tester
 

--- a/src/scratch/intro_til_programmering_nn.md
+++ b/src/scratch/intro_til_programmering_nn.md
@@ -59,19 +59,22 @@ og mykje meir.
 
 ## Løkker
 
-Veldig ofte har me behov for å gjere nokre instruksar fleire gonger. La oss seie
-at me vil at datamaskina vår skal lage (data)pannekaker. Då vil me at
-datamaskina skal hente eit egg, knuse det i bollen og røre rundt. Og me vil at
-den skal gjere det mange gonger. Då kan me bruke det som heiter ei __løkke__ for
-å be den gjere den same oppgåva (blande inn eit egg) så mange gonger me vil. I
-Scratch finn me alle løkkene under `Styring`{.blockyellow}-kategorien. Viss me
-vil at noko skal bli repetert eit bestemt tal gonger brukar me ein `gjenta (10)
-ganger`{.blockyellow}-blokk. Du legg kanskje merke til at denne blokka ikkje er
-som alle andre blokker? Den har nemleg eit lite holrom der du kan setje inn dei
-instruksane du vil skal repeterast. Ein annan viktig type løkke heiter `for
-alltid`{.blockyellow}. I staden for å repetere noko eit bestemt tal gonger, så
-repeterer den noko *for alltid*. Då gjeld det å vere forsiktig så ein ikkje
-ender opp med ei uendeleg stor eggerøre!
+Veldig ofte har me behov for å gjere nokre instruksar fleire
+gonger. La oss seie at me vil at datamaskina vår skal lage
+(data)pannekaker. Då vil me at datamaskina skal hente eit egg, knuse
+det i bollen og røre rundt. Og me vil at den skal gjere det mange
+gonger. Då kan me bruke det som heiter ei __løkke__ for å be den gjere
+den same oppgåva (blande inn eit egg) så mange gonger me vil. I
+Scratch finn me alle løkkene under
+`Styring`{.blockyellow}-kategorien. Viss me vil at noko skal bli
+repetert eit bestemt tal gonger brukar me ein `gjenta (10)
+ganger`{.blockyellow}-blokk. Du legg kanskje merke til at denne blokka
+ikkje er som alle andre blokker? Den har nemleg eit lite holrom der du
+kan setje inn dei instruksane du vil skal repeterast. Ein annan viktig
+type løkke heiter `gjenta for alltid`{.blockyellow}. I staden for å
+repetere noko eit bestemt tal gonger, så repeterer den noko *for
+alltid*. Då gjeld det å vere forsiktig så ein ikkje ender opp med ei
+uendeleg stor eggerøre!
 
 ## Testar
 

--- a/src/scratch/jafsefisk/jafsefisk_nn.md
+++ b/src/scratch/jafsefisk/jafsefisk_nn.md
@@ -44,7 +44,7 @@ Jafsefisk med å ete alle byttedyra som svømmer rundt i havet.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       peik mot [musepeikar v]
       gå (3) steg
   slutt
@@ -68,7 +68,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       viss <(avstand til [musepeikar v]) > [10]>
           peik mot [musepeikar v]
           gå (3) steg
@@ -106,7 +106,7 @@ rørslene.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå (2) steg
       snu @turnLeft (tilfeldig tal frå (-20) til (20)) gradar
       viss ved kant, sprett
@@ -149,7 +149,7 @@ lita stund seinare.
   ```blocks
   når @greenFlag vert trykt på
   vis
-  for alltid
+  gjenta for alltid
       gå (2) steg
       snu @turnLeft (tilfeldig tal frå (-20) til (20)) gradar
       viss ved kant, sprett
@@ -189,7 +189,7 @@ Slik skal skriptet til byttedyret sjå ut:
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå (2) steg
       snu @turnLeft (tilfeldig tal frå (-20) til (20)) gradar
       viss ved kant, sprett
@@ -224,7 +224,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå (2) steg
       snu @turnLeft (tilfeldig tal frå (-20) til (20)) gradar
       viss ved kant, sprett

--- a/src/scratch/julekort/julekort_nn.md
+++ b/src/scratch/julekort/julekort_nn.md
@@ -74,7 +74,7 @@ __Klikk på isbjørnen og sjå om koden din virkar.__
   når denne figuren vert trykt på
   spør [Kva heiter du ?] og vent
   sei (set saman  [God jul ] (svar)) i (2) sekund
-  for alltid
+  gjenta for alltid
       endra  [farge v]-effekt med (25)
   slutt
   ```
@@ -96,7 +96,7 @@ koden. No skal juletreet skifte farge og utsjånad.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       vent (0.3) sekund
       endra [farge v]-effekt med (25)
       neste drakt

--- a/src/scratch/kingkong/kingkong.md
+++ b/src/scratch/kingkong/kingkong.md
@@ -294,7 +294,7 @@ spillet kan videreutvikles?
 
 - [ ] Tell poeng! Kanskje du kan få poeng for hvert fly som passerer?
 
-- [ ] Tell liv! King Kong kan ikke bli truffet av flyene `for
+- [ ] Tell liv! King Kong kan ikke bli truffet av flyene `gjenta for
   alltid`{.blockcontrol}. Legg til en `liv`{.blockdata}-variabel som teller hvor
   mange liv du har igjen. Kanskje `kong` ramler ned fra skyskraperen når han er
   tom for liv?

--- a/src/scratch/kingkong/kingkong_nn.md
+++ b/src/scratch/kingkong/kingkong_nn.md
@@ -168,7 +168,7 @@ No har me tatt inn grafikken me treng. Det er på tide å begynne å programmere
   når @greenFlag vert trykt på
   gå til x: (-45) y: (30)
   byt drakt til [venstre v]
-  for alltid
+  gjenta for alltid
       viss <tasten [pil venstre v] er trykt?>
           gli (0.2) sekund til x: (-45) y: (30)
           byt drakt til [venstre v]
@@ -206,7 +206,7 @@ skyskraparen.
   når @greenFlag vert trykt på
   gøym
   avgrens rotering til [venstre-høgre v]
-  for alltid
+  gjenta for alltid
       vent (tilfeldig tal frå (0.5) til (4)) sekund
       lag klon av [meg v]
   slutt
@@ -269,7 +269,7 @@ Oppgåva til **King Kong** er å passe seg slik at han ikkje blir treft av flya.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       vent til <rører [fly v] ?>
       endra [farge v]-effekt med (25)
       vent (0.5) sekund
@@ -292,7 +292,7 @@ korleis du kan vidareutvikle spelet?
 
 - [ ] Tell poeng! Kanskje du kan få poeng for kvart fly som passerer?
 
-- [ ] Tell liv! King Kong kan ikkje bli treft av flya `for
+- [ ] Tell liv! King Kong kan ikkje bli treft av flya `gjenta for
   alltid`{.blockcontrol}. Legg til ein `liv`{.blockdata}-variabel som tel kor
   mange liv du har att. Kanskje `kong` ramlar ned frå skyskraparen når han er
   tom for liv?

--- a/src/scratch/labyrint/README.md
+++ b/src/scratch/labyrint/README.md
@@ -128,8 +128,9 @@ elever som har lyst å prøve seg på en løsning kan du foreslå følgende:
   pågår, som sjekkes hver gang spilleren trykker en piltast, før utforskeren
   flytter seg. Sett variabelen til `true` eller `1` når spillet er over.
 
-- [ ] En mer vanlig (og bedre) løsning er å bruke en `for alltid`-løkke med
-  `hvis ... trykket?`-klosser. Disse blir da stoppet av `stopp alle`-klossen.
+- [ ] En mer vanlig (og bedre) løsning er å bruke en `gjenta for alltid`-løkke
+  med `hvis ... trykket?`-klosser. Disse blir da stoppet av `stopp
+  alle`-klossen.
 
 ## Variasjoner {.challenge}
 

--- a/src/scratch/labyrint/README_nn.md
+++ b/src/scratch/labyrint/README_nn.md
@@ -125,8 +125,8 @@ For elevar som har lyst å prøve seg på ei løysing kan du foreslå det følgj
   utforskaren flyttar seg. Set variabelen til `true` eller `1` når spelet er
   over.
 
-- [ ] Ei meir vanleg (og betre) løysing er å bruke ei `for alltid`-løkke med
-  `viss ... er trykt?`-klossar. Desse blir stoppa av `stopp alle`-klossen.
+- [ ] Ei meir vanleg (og betre) løysing er å bruke ei `gjenta for alltid`-løkke
+  med `viss ... er trykt?`-klossar. Desse blir stoppa av `stopp alle`-klossen.
 
 ## Variasjonar {.challenge}
 

--- a/src/scratch/labyrint/labyrint_nn.md
+++ b/src/scratch/labyrint/labyrint_nn.md
@@ -195,7 +195,7 @@ veggane i labyrinten i same farge.
   ```blocks
   når @greenFlag vert trykt på
   set [hastigheit v] til [10]
-  for alltid
+  gjenta for alltid
       viss <rører fargen [#cc0000]?>
           snu @turnRight (180) gradar
           gå (hastigheit) steg
@@ -266,7 +266,7 @@ skriptet på `Skatt`.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       viss <rører [Utforskar v]?>
           gøym
       slutt
@@ -293,7 +293,7 @@ gong, forblir skatten borte.
   ```blocks
   når @greenFlag vert trykt på
   vis
-  for alltid
+  gjenta for alltid
       viss <rører [Utforskar v]?>
           gøym
       slutt
@@ -321,7 +321,7 @@ der den fann skatten sist. Det blir ikkje veldig spanande.
   når @greenFlag vert trykt på
   set [hastigheit v] til [10]
   gå til x: (-200) y: (0)
-  for alltid
+  gjenta for alltid
       viss <rører fargen [#cc0000]?>
           snu @turnRight (180) gradar
           gå (hastigheit) steg
@@ -360,7 +360,7 @@ veldig likt korleis `Skatt` merka at den vart funne.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       viss <rører [Utforskar v]?>
           sei [Tok deg!] i (1) sekund
           stopp [alle v] :: control
@@ -407,7 +407,7 @@ Til slutt skal me få froskekongen til å bevege seg rundt i labyrinten.
   gå til x: (50) y: (100)
   peik i retning (-90 v)
   set [hastigheit v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
       viss <rører fargen [#cc0000]?>
           snu @turnRight (180) gradar
@@ -426,7 +426,7 @@ retning av og til.
   gå til x: (50) y: (100)
   peik i retning (-90 v)
   set [hastigheit v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
       viss <rører fargen [#cc0000]?>
           snu @turnRight (180) gradar

--- a/src/scratch/lunar_lander/lunar_lander.md
+++ b/src/scratch/lunar_lander/lunar_lander.md
@@ -100,7 +100,7 @@ i forhold til den skrå streken.
 - [ ] Vi vil nå programmere kontrollen av romskipet. Først og fremst vil vi at
   romskipet vender seg når vi trykker på piltastene mot høyre og venstre.
 
-  Legg til to `hvis`{.blockcontrol}-blokker inne i `for
+  Legg til to `hvis`{.blockcontrol}-blokker inne i `gjenta for
   alltid`{.blockcontrol}-løkken hvor du `vender`{.blockmotion} romskipet for
   eksempel `5` grader mot høyre eller venstre avhengig av hvilken piltast som
   trykkes.

--- a/src/scratch/lunar_lander/lunar_lander_nn.md
+++ b/src/scratch/lunar_lander/lunar_lander_nn.md
@@ -80,7 +80,7 @@ til den skrå streken.
       peik i retning (90 v)
       set [fartX v] til (0)
       set [fartY v] til (0)
-      for alltid
+      gjenta for alltid
           endra [fartY v] med (-0.01)
           endra x med (fartX)
           endra y med (fartY)
@@ -101,7 +101,7 @@ til den skrå streken.
 - [ ] Me vil nå programmera kontrollen av romskipet. Først og fremst vil me at
       romskipet vender seg når me trykker på piltastene mot høgre og venstre.
 
-  Legg til to `viss`{.blockcontrol}-blokker inne i `for
+  Legg til to `viss`{.blockcontrol}-blokker inne i `gjenta for
   alltid`{.blockcontrol}-løkken hvor du `vender`{.blockmotion} romskipet for
   eksempel `5` grader mot høgre eller venstre avhengig av kva piltast du trykker
   på.
@@ -109,7 +109,7 @@ til den skrå streken.
 - [ ] Når du trykker pil opp-tasten vil me at romskipet skal få litt ekstra fart
       i den retninga romskipet peikar. Som me snakka om tidlegare kan me bruke
       dei matematiske funksjonane sinus og cosinus for å få til dette. Legg og
-      til denne blokken inne i `for alltid`{.blockcontrol}-løkken din.
+      til denne blokken inne i `gjenta for alltid`{.blockcontrol}-løkken din.
 
   ```blocks
       viss <tasten [pil opp v] er trykt?>
@@ -154,9 +154,10 @@ til den skrå streken.
       landingsplassen.
 
 - [ ] For at romskipet skal slutta å fly når det treff bakken kan du byte ut
-      `for alltid`{.blockcontrol}-løkk med ein `gjenta til`{.blockcontrol}-løkke
-      der du testar på om romskipet `rører fargen`{.blocksensing} du har brukt
-      på landskapet eller på landingsplassen.
+      `gjenta for alltid`{.blockcontrol}-løkk med ein `gjenta
+      til`{.blockcontrol}-løkke der du testar på om romskipet `rører
+      fargen`{.blocksensing} du har brukt på landskapet eller på
+      landingsplassen.
 
 - [ ] Legg og til ein `send meldinga [Sjekk landing v]`{.b} rett etter `gjenta
       til`{.blockcontrol}-løkken.

--- a/src/scratch/norgestur/norgestur.md
+++ b/src/scratch/norgestur/norgestur.md
@@ -82,7 +82,7 @@ andre kart.
   når grønt flagg klikkes
   sett størrelse til (25) %
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       hvis <tast [pil opp v] trykket?>
           pek i retning (0 v)
           gå (2) steg
@@ -109,7 +109,7 @@ Vi skal nå programmere de andre piltastene også.
   koden som flytter helikopteret oppover. Vi kan derfor kopiere denne!
   Høyreklikk på klossen `hvis `{.blockcontrol}`tast pil opp
   trykket?`{.blocksensing}, og velg `lag en kopi`. Slipp disse klossene inn i
-  `for alltid`{.blockcontrol}-løkken. Gjenta til du har fire
+  `gjenta for alltid`{.blockcontrol}-løkken. Gjenta til du har fire
   `hvis`{.blockcontrol}-klosser. Endre på skriptet ditt slik at det ser ut som
   følger:
 
@@ -117,7 +117,7 @@ Vi skal nå programmere de andre piltastene også.
   når grønt flagg klikkes
   sett størrelse til (25) %
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       hvis <tast [pil opp v] trykket?>
           pek i retning (0 v)
           gå (2) steg

--- a/src/scratch/norgestur/norgestur_nn.md
+++ b/src/scratch/norgestur/norgestur_nn.md
@@ -80,7 +80,7 @@ oppgåva finn du beskrivingar for å bruke andre kart.
   når @greenFlag vert trykt på
   set storleik til (25) %
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       viss <tasten [pil opp v] er trykt?>
           peik i retning (0 v)
           gå (2) steg
@@ -107,7 +107,7 @@ Me skal programmere dei andre piltastane òg.
   koden som flyttar helikopteret oppover. Difor kan me kopiere den me allereie
   har skrive! Høgreklikk på klossen `viss `{.blockcontrol}`tasten pil opp
   er trykt?`{.blocksensing}, og vel `lag ein kopi`. Slepp desse klossane inn i
-  `for alltid`{.blockcontrol}-løkka. Gjenta til du har fire
+  `gjenta for alltid`{.blockcontrol}-løkka. Gjenta til du har fire
   `viss`{.blockcontrol}-klossar. Endre på skriptet ditt slik at det ser ut som
   følgjer:
 
@@ -115,7 +115,7 @@ Me skal programmere dei andre piltastane òg.
   når @greenFlag vert trykt på
   set storleik til (25) %
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       viss <tasten [pil opp v] er trykt?>
           peik i retning (0 v)
           gå (2) steg

--- a/src/scratch/orkenlop/orkenlop.md
+++ b/src/scratch/orkenlop/orkenlop.md
@@ -9,7 +9,7 @@ language: nb
 
 # Introduksjon {.intro}
 
-Dette er et spill for to, der en papegøye og en løvinne kjemper om å
+Dette er et spill for to, der en papegøye og en løve kjemper om å
 komme først gjennom ørkenen. Hver spiller må trykke en tast så fort og
 ofte som mulig for å flytte figuren sin, og den som kommer først til
 kanten av skjermen vinner.
@@ -25,20 +25,20 @@ kanten av skjermen vinner.
 
 - [ ] Klikk på Scene og velg en ferdig bakgrunn,
   ![velg en ferdig bakgrunn](../bilder/bakgrunn-fra-bibliotek.png). Velg
-  `Natur/desert`.
+  `Alle/desert`.
 
 - [ ] Fjern katten ved å høyreklikke på figuren og velg `slett`.
 
 - [ ] Legg til en ny figur ved å trykke på
   ![velg figur fra biblioteket](../bilder/hent-fra-bibliotek.png). Velg
-  `Dyr/Lionness`.
+  `Dyr/Lion`.
 
-- [ ] Legg så til enda en ny figur: velg `Dyr/Parrot`. Krymp figuren slik
-  at den er omtrent like stor som løvinnen ved å bruke
-  ![krymp](../bilder/krymp.png).
+- [ ] Legg så til enda en ny figur: velg `Dyr/Parrot`. Krymp figuren
+  slik at den er omtrent like stor som løven ved å endre tallet i
+  "Størrelse" ruten.
 
 
-# Steg 2: La løvinnen og papegøyen bevege seg {.activity}
+# Steg 2: La løven og papegøyen bevege seg {.activity}
 
 *Vi vil at figurene skal bevege seg når du trykker på en knapp.*
 
@@ -64,7 +64,7 @@ kanten av skjermen vinner.
 
 __Klikk på det grønne flagget.__
 
-- [ ] Beveger løvinnen og papegøyen seg over skjermen når du trykker på
+- [ ] Beveger løven og papegøyen seg over skjermen når du trykker på
   `A` og `L` tastene?
 
 
@@ -75,7 +75,7 @@ __Klikk på det grønne flagget.__
 
 ## Sjekkliste {.check}
 
-- [ ] Legg til en ny figur. Velg `Ting/Button3`. Flytt den til midten av
+- [ ] Legg til en ny figur. Velg `Alle/Button3`. Flytt den til midten av
   scenen.
 
 - [ ] Klikk på `Drakter`-fanen og verktøyet `T` for å legge til
@@ -150,13 +150,13 @@ og vi ønsker å vite når kappløpet er over.
   slutt
   ```
 
-- [ ] Gjenta det samme for løvinnen.
+- [ ] Gjenta det samme for løven.
 
 ## Test prosjektet {.flag}
 
 __Klikk på det grønne flagget.__
 
-- [ ] Kan løvinnen og papegøyen bare flytte seg når nedtellingen er
+- [ ] Kan løven og papegøyen bare flytte seg når nedtellingen er
   ferdig?
 
 
@@ -204,7 +204,7 @@ __Klikk på det grønne flagget.__
   slutt
   ```
 
-- [ ] Gjør tilsvarende for løvinnen.
+- [ ] Gjør tilsvarende for løven.
 
 ## Test prosjektet {.flag}
 
@@ -247,8 +247,8 @@ __Klikk på det grønne flagget.__
   sett x til (-170)
   ```
 
-- [ ] Gjør det samme for løvinnen. Test forskjellige `x`-verdier for å
-  være sikker på at løvinnen og papegøyen starter fra samme sted.
+- [ ] Gjør det samme for løven. Test forskjellige `x`-verdier for å
+  være sikker på at løven og papegøyen starter fra samme sted.
 
 - [ ] For at figurene skal stå på startstreken når kappløpet starter den
   aller første gangen må vi også legge til følgende klosser på begge
@@ -274,7 +274,7 @@ __Klikk på det grønne flagget.__
 __Klikk på det grønne flagget.__
 
 - [ ] Kan du spille mot en venn? En av dere styrer papegøyen ved å trykke
-  `A`, og den andre løvinnen ved å trykke `L`.
+  `A`, og den andre løven ved å trykke `L`.
 
 ## Lagre prosjektet {.save}
 
@@ -287,7 +287,7 @@ spillet og gjøre det enda mer interessant.
 ## Utfordring 1: Legg til en rakett! {.challenge}
 
 - [ ] __Legg til en rakett__ som kan brukes én gang per kappløp og som
-  flytter papegøyen eller løvinnen __30 steg på en gang.__
+  flytter papegøyen eller løven __30 steg på en gang.__
 
 - [ ] __Legg til en ny drakt__ med ild som kommer ut bak figurene. La
   denne aktiveres når raketten avfyres.
@@ -377,7 +377,7 @@ som at vi lager vår egen Scratch-kodekloss!
   ```
 
 - [ ] Gjør dette koden din enklere å lese? Kan du lage en tilsvarende
-  egendefinert kloss for løvinnen?
+  egendefinert kloss for løven?
 
 ## Test prosjektet {.flag}
 
@@ -385,7 +385,7 @@ __Klikk på det grønne flagget.__
 
 * Virker spillet fortsatt slik det skal?
 
-* Er spillet ferdig når papegøyen eller løvinnen kommer til kanten av
+* Er spillet ferdig når papegøyen eller løven kommer til kanten av
   skjermen?
 
 ## Lagre prosjektet {.save}

--- a/src/scratch/pingviner_pa_tur/pingviner_pa_tur_nn.md
+++ b/src/scratch/pingviner_pa_tur/pingviner_pa_tur_nn.md
@@ -73,7 +73,7 @@ seg._
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå (10) steg
       viss ved kant, sprett
   slutt
@@ -132,7 +132,7 @@ _No vil me få pingvinen til å bevege seg på kryss og tvers._
   når @greenFlag vert trykt på
   set storleik til (40) %
   avgrens rotering til [venstre-høgre v]
-  for alltid
+  gjenta for alltid
       gå (4) steg
       viss ved kant, sprett
   slutt
@@ -147,7 +147,7 @@ _No vil me få pingvinen til å bevege seg på kryss og tvers._
   avgrens rotering til [venstre-høgre v]
   gå til [tilfeldig stad v]
   peik i retning (tilfeldig tal frå (1) til (360))
-  for alltid
+  gjenta for alltid
       gå (4) steg
       viss ved kant, sprett
   slutt
@@ -253,7 +253,7 @@ _Til slutt skal me få pingvinen til å oppdage at den har kome heim!_
   avgrens rotering til [venstre-høgre v]
   gå til [tilfeldig stad v]
   peik i retning (tilfeldig tal frå (1) til (360))
-  for alltid
+  gjenta for alltid
       gå (4) steg
       viss ved kant, sprett
       viss <rører [Akvariet v] ?>
@@ -282,7 +282,7 @@ nokre idear:
   av den.
 
 - [ ] Kan du lage ein test for om _alle_ pingvinane har kome heim? Den er
-  enklast å lage på akvariefiguren. Du bør bruke ei `for
+  enklast å lage på akvariefiguren. Du bør bruke ei `gjenta for
   alltid`{.blockcontrol}-løkke, ein `viss`{.blockcontrol}-test samt
   `< > og < >`{.b}- og `rører [ v]`{.b}-klossar.
 

--- a/src/scratch/pong/pong_nn.md
+++ b/src/scratch/pong/pong_nn.md
@@ -64,7 +64,7 @@ Ingen spelarar, ingen poeng, ingenting anna enn ein sprettande ball!
   set [hastigheit v] til [7]
   gå til x: (0) y: (0)
   peik i retning (tilfeldig tal frå (1) til (360))
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
       viss ved kant, sprett
   slutt
@@ -116,7 +116,7 @@ racketane til spelarane) eller når den er borti spesielle farger.
   telje poeng. Det kan me gjere ved å bytte ut
 
   ```blocks
-  for alltid
+  gjenta for alltid
   slutt
   ```
 

--- a/src/scratch/snoballkrig/README.md
+++ b/src/scratch/snoballkrig/README.md
@@ -94,7 +94,7 @@ eksempel på hvordan koden kan se ut under de forskjellige elementene._
   når jeg mottar [start v]
   sett [Poeng v] til [0]
   bytt bakgrunn til [Spill v]
-  for alltid
+  gjenta for alltid
     sett [Nivå v] til ((1) + ([gulv v] av ([kvadratrot v] av ((Poeng) / (3)))))
   slutt
 
@@ -116,7 +116,7 @@ eksempel på hvordan koden kan se ut under de forskjellige elementene._
   når jeg mottar [start v]
   gå til x: (0) y: (-75)
   vis
-  for alltid
+  gjenta for alltid
     hvis <tast [pil høyre v] trykket?>
       pek i retning (90 v)
       neste drakt
@@ -179,7 +179,7 @@ eksempel på hvordan koden kan se ut under de forskjellige elementene._
   sett [hastighet v] til [3]
 
   når jeg mottar [start v]
-  for alltid
+  gjenta for alltid
     hvis <(tilfeldig tall fra (0) til (1)) = [0]>
       pek i retning (90 v)
       sett x til (-250)
@@ -198,13 +198,13 @@ eksempel på hvordan koden kan se ut under de forskjellige elementene._
   endre [farge v] effekt med ((10) * (Slem))
   endre størrelse med ((5) * (Slem))
   vis
-  for alltid
+  gjenta for alltid
     gå (hastighet) steg
     vent (0.1) sekunder
   slutt
 
   når jeg starter som klon
-  for alltid
+  gjenta for alltid
     hvis <berører [Helten v]?>
       send melding [slutt v]
     slutt

--- a/src/scratch/snoballkrig/README_nn.md
+++ b/src/scratch/snoballkrig/README_nn.md
@@ -95,7 +95,7 @@ _Det kan vere ei utfordring for mange elevar å lage koden. Under følgjer eit d
   når eg får meldinga [start v]
   set [Poeng v] til [0]
   byt bakgrunn til [Spill v]
-  for alltid
+  gjenta for alltid
     set [Nivå v] til ((1) + ([golv v] av ([kvadratrot v] av ((Poeng) / (3)))))
   slutt
 
@@ -117,7 +117,7 @@ _Det kan vere ei utfordring for mange elevar å lage koden. Under følgjer eit d
   når eg får meldinga [start v]
   gå til x: (0) y: (-75)
   vis
-  for alltid
+  gjenta for alltid
     viss <tasten [pil høgre v] er trykt?>
       peik i retning (90 v)
       neste drakt
@@ -180,7 +180,7 @@ _Det kan vere ei utfordring for mange elevar å lage koden. Under følgjer eit d
   set [hastigheit v] til [3]
 
   når eg får meldinga [start v]
-  for alltid
+  gjenta for alltid
     viss <(tilfeldig tal frå (0) til (1)) = [0]>
       peik i retning (90 v)
       set x til (-250)
@@ -199,13 +199,13 @@ _Det kan vere ei utfordring for mange elevar å lage koden. Under følgjer eit d
   endre [farge v]-effekt med ((10) * (Slem))
   endre storleik med ((5) * (Slem))
   vis
-  for alltid
+  gjenta for alltid
     gå (hastigheit) steg
     vent (0.1) sekund
   slutt
 
   når eg startar som klon
-  for alltid
+  gjenta for alltid
     viss <rører [Helten v]?>
       send meldinga [slutt v]
     slutt

--- a/src/scratch/snoballkrig/snoballkrig_nn.md
+++ b/src/scratch/snoballkrig/snoballkrig_nn.md
@@ -75,7 +75,7 @@ raskare og vanskelegare å jage bort.
   ```blocks
   når eg får meldinga [start v]
   gå til x: (0) y: (-75)
-  for alltid
+  gjenta for alltid
   slutt
   ```
 
@@ -203,7 +203,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når eg får meldinga [start v]
-  for alltid
+  gjenta for alltid
       viss <(tilfeldig tal frå (0) til (1)) = [0]>
           peik i retning (90 v)
           set x til (-250)
@@ -229,7 +229,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når eg startar som klon
-  for alltid
+  gjenta for alltid
       viss <rører [Helten v]?>
           send meldinga [slutt v]
           slett denne klonen
@@ -334,7 +334,7 @@ __Klikk på det grøne flagget.__
   tek imot `start`-meldinga på scena med den følgjande løkka:
 
   ```blocks
-  for alltid
+  gjenta for alltid
       set [Nivå v] til ((1) + ([golv v] av ((Poeng) / (5))))
   slutt
   ```
@@ -360,7 +360,7 @@ __Klikk på det grøne flagget.__
   endra [farge v]-effekt med ((10) * (Slem))
   endra storleik med ((5) * (Slem))
   vis
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
       vent (0.1) sekund
   slutt
@@ -380,7 +380,7 @@ __Klikk på det grøne flagget.__
   mykje vanskelegare. Til dømes kan du bruke denne utrekninga:
 
   ```blocks
-  for alltid
+  gjenta for alltid
       set [Nivå v] til ((1) + ([gulv v] av ([kvadratrot v] av ((Poeng) / (3)))))
   slutt
   ```

--- a/src/scratch/snurrige_figurer/snurrige_figurer.md
+++ b/src/scratch/snurrige_figurer/snurrige_figurer.md
@@ -33,7 +33,7 @@ figur.*
 
     Gå til ![Velg drakt fra biblioteket](../bilder/hent-fra-bibliotek.png) nede i høyre hjørne og klikk på
     ![Tegn ny figur](../bilder/tegn-ny.png) for å tegne din egen figur. Bruk
-    linjeverktøyet, ![Linje](../bilder/tegn-linje.png), til å tegne en trekant. 
+    linjeverktøyet, ![Linje](../bilder/tegn-linje.png), til å tegne en trekant.
 
     ![Bilde av en trekant i Scratch](tegn_trekant.png)
 
@@ -141,7 +141,7 @@ __Trykk på B-tasten.__
 
   ```blocks
   når jeg mottar [snurr v]
-  for alltid
+  gjenta for alltid
       snu @turnRight (4) grader
   slutt
   ```
@@ -165,7 +165,7 @@ __Trykk på B-tasten.__
 
   ```blocks
   når jeg mottar [flytt og snurr v]
-  for alltid
+  gjenta for alltid
       gå (3) steg
       snu @turnRight (4) grader
   slutt

--- a/src/scratch/snurrige_figurer/snurrige_figurer_nn.md
+++ b/src/scratch/snurrige_figurer/snurrige_figurer_nn.md
@@ -137,7 +137,7 @@ __Trykk på B-tasten.__
 
   ```blocks
   når eg får meldinga [snurr v]
-  for alltid
+  gjenta for alltid
       snu @turnRight (4) gradar
   slutt
   ```
@@ -161,7 +161,7 @@ __Trykk på B-tasten.__
 
   ```blocks
   når eg får meldinga [flytt og snurr v]
-  for alltid
+  gjenta for alltid
       gå (3) steg
       snu @turnRight (4) gradar
   slutt

--- a/src/scratch/soloball/soloball_nn.md
+++ b/src/scratch/soloball/soloball_nn.md
@@ -28,7 +28,7 @@ du styre katten som kontrollerer ballen slik at ballen ikkje går i nettet.
   ```blocks
   når @greenFlag vert trykt på
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       peik mot [musepeikar v]
   slutt
   ```
@@ -135,7 +135,7 @@ rundt dette punktet i staden for at den berre roterer utan å flytte seg.
   ```blocks
   når @greenFlag vert trykt på
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       gå (3) steg
       viss <rører [Katt v] ?>
           peik i retning ((180) + (retning))
@@ -238,7 +238,7 @@ Det skal me gjere no.
   ```blocks
   når @greenFlag vert trykt på
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       gå (3) steg
       viss <rører [Katt v] ?>
           peik i retning ((180) + (retning))
@@ -311,7 +311,7 @@ Me kan forenkle dette til
   ```blocks
   når @greenFlag vert trykt på
   gå til x: (0) y: (0)
-  for alltid
+  gjenta for alltid
       gå (3) steg
       viss <rører [Katt v] ?>
           peik i retning (((180) - (retning)) + ((2) * ([retning v] av [Katt v])))
@@ -370,7 +370,7 @@ skal me få eitt poeng kvar gong me returnerer ballen.
   når @greenFlag vert trykt på
   gå til x: (0) y: (0)
   set [Poeng v] til [0]
-  for alltid
+  gjenta for alltid
       gå (3) steg
       viss <rører [Katt v] ?>
           peik i retning (((180) - (retning)) + ((2) * ([retning v] av [Katt v])))
@@ -416,7 +416,7 @@ Ved å endre på 3-talet endrar me hastigheita på ballen. Prøv å gjere det sj
   gå til x: (0) y: (0)
   set [Poeng v] til [0]
   set [Hastigheit v] til [3]
-  for alltid
+  gjenta for alltid
       gå (Hastigheit) steg
       viss <rører [Katt v] ?>
           peik i retning (((180) - (retning)) + ((2) * ([retning v] av [Katt v])))
@@ -458,7 +458,7 @@ snu viss den har flytta mange gonger sidan sist den snudde.
   gå til x: (0) y: (0)
   set [Poeng v] til [0]
   set [Hastigheit v] til [3]
-  for alltid
+  gjenta for alltid
       gå (Hastigheit) steg
       endra [Flytt v] med (1)
       viss <<rører [Katt v] ?> og <(Flytt) > [20]>>

--- a/src/scratch/spokelsesjakten/spokelsesjakten.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten.md
@@ -53,7 +53,7 @@ i gang.
   ```blocks
   når grønt flagg klikkes
   sett [hastighet v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastighet) steg
   slutt
   ```
@@ -75,7 +75,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   sett [hastighet v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastighet) steg
       sprett tilbake ved kanten
   slutt
@@ -119,7 +119,7 @@ __Klikk på det grønne flagget.__
 
   ```blocks
   når grønt flagg klikkes
-  for alltid
+  gjenta for alltid
       vis
       vent (tilfeldig tall fra (3) til (5)) sekunder
       skjul

--- a/src/scratch/spokelsesjakten/spokelsesjakten_nn.md
+++ b/src/scratch/spokelsesjakten/spokelsesjakten_nn.md
@@ -52,7 +52,7 @@ Denne kan me bruke til å endre hastigheita undervegs i spelet seinare.
   ```blocks
   når @greenFlag vert trykt på
   set [hastigheit v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
   slutt
   ```
@@ -74,7 +74,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   set [hastigheit v] til [5]
-  for alltid
+  gjenta for alltid
       gå (hastigheit) steg
       viss ved kant, sprett
   slutt
@@ -116,7 +116,7 @@ __Klikk på det grøne flagget.__
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       vis
       vent (tilfeldig tal frå (3) til (5)) sekund
       gøym

--- a/src/scratch/straffespark/README.md
+++ b/src/scratch/straffespark/README.md
@@ -179,7 +179,7 @@ kreativitet. Elevene kan gjerne oppfordres til å
       det Kattens oppførsel vi må beskrive_).
 
       ```blocks
-      for alltid
+      gjenta for alltid
           pek mot [Bat1 v]
           gå (10) steg
       slutt
@@ -195,7 +195,7 @@ kreativitet. Elevene kan gjerne oppfordres til å
       er et eksempel (husk at koden hører til flaggermusa):
 
       ```blocks
-      for alltid
+      gjenta for alltid
           vent til <berører [Sprite1 v]>
           gli (0.2) sekunder til x: (tilfeldig tall fra (-240) til (240)) y: (tilfeldig tall fra (-180) til (180))
       slutt
@@ -211,7 +211,7 @@ kreativitet. Elevene kan gjerne oppfordres til å
       eksisterer i Scratch):
 
       ```blocks
-      for alltid
+      gjenta for alltid
           flytt [katten v] mot [flaggermusa v] :: motion
           hvis <[katten v] berører [flaggermusa v] :: sensing>
               flytt [flaggermusa v] til x: (tilfeldig tall fra (-240) til (240)) y: (tilfeldig tall fra (-180) til (180)) :: motion

--- a/src/scratch/straffespark/README_nn.md
+++ b/src/scratch/straffespark/README_nn.md
@@ -177,7 +177,7 @@ kreativitet. Elevane kan gjerne oppfordrast til å
     beveger seg).
 
     ```blocks
-    for alltid
+    gjenta for alltid
         peik mot [Bat1 v]
         gå (10) steg
     slutt
@@ -193,7 +193,7 @@ kreativitet. Elevane kan gjerne oppfordrast til å
     eit døme (hugs at koden høyrer til flaggermusa):
 
     ```blocks
-    for alltid
+    gjenta for alltid
         vent til <rører [Sprite1 v]>
         gli (0.2) sekund til x: (tilfeldig tal frå (-240) til (240)) y: (tilfeldig tal frå (-180) til (180))
     slutt
@@ -209,7 +209,7 @@ kreativitet. Elevane kan gjerne oppfordrast til å
     ikkje i Scratch):
 
     ```blocks
-    for alltid
+    gjenta for alltid
         flytt [katten v] mot [flaggermusa v] :: motion
         viss <[katten v] rører [flaggermusa v] :: sensing>
             flytt [flaggermusa v] til x: (tilfeldig tal frå (-240) til (240)) y: (tilfeldig tal frå (-180) til (180)) :: motion

--- a/src/scratch/straffespark/straffespark_nn.md
+++ b/src/scratch/straffespark/straffespark_nn.md
@@ -104,7 +104,7 @@ innimellom.
   når @greenFlag vert trykt på
   gå til x: (-125) y: (-60)
   vent til <rører [Leo v]?>
-  for alltid
+  gjenta for alltid
       gå (6) steg
   slutt
   ```
@@ -151,7 +151,7 @@ __Klikk på det grøne flagget.__
   når @greenFlag vert trykt på
   gå til x: (100) y: (-50)
   peik i retning (0 v)
-  for alltid
+  gjenta for alltid
       gå (15) steg
       viss ved kant, sprett
   slutt
@@ -179,7 +179,7 @@ __Klikk på det grøne flagget.__
   endre storleiken på er ved å bruke klossar frå
   `Utseende`{.blocklooks}-kategorien.
 
-  Legg inn klossen `set storleik til (100)%`{.b} i `for
+  Legg inn klossen `set storleik til (100)%`{.b} i `gjenta for
   alltid`{.blockcontrol}-løkka. No kan du eksperimentere med å endre `100%` til
   eit anna tal til du får ein passe stor målmann. Viss du har brukt blekkspruten
   som `Målmann` passar `50%` ganske bra. Prøv deg fram!
@@ -209,7 +209,7 @@ når ballen går i mål.
   når @greenFlag vert trykt på
   gå til x: (-125) y: (-60)
   vent til <rører [Leo v]?>
-  for alltid
+  gjenta for alltid
       gå (6) steg
       viss <rører [Målmann v]?>
           send meldinga [Redning v]
@@ -262,7 +262,7 @@ Desse viser koordinatane til musepeikaren.
   når @greenFlag vert trykt på
   gå til x: (-125) y: (-60)
   vent til <rører [Leo v]?>
-  for alltid
+  gjenta for alltid
       gå (6) steg
       viss <rører [Målmann v]?>
           send meldinga [Redning v]

--- a/src/scratch/tegneprogram/tegneprogram.md
+++ b/src/scratch/tegneprogram/tegneprogram.md
@@ -53,12 +53,12 @@ Denne første delen kan du godt få hjelp fra en voksen til å gjøre!
 
   ![Bilde av en blyant med flyttet senterpunkt](senterpunkt.png)
 
-- [ ] Få blyanten til å følge musepekeren rundt på scenen ved å bruke `for
-  alltid`{.blockcontrol}- og `gå til musepeker`{.blockmotion}-klossene.
+- [ ] Få blyanten til å følge musepekeren rundt på scenen ved å bruke `gjenta
+  for alltid`{.blockcontrol}- og `gå til musepeker`{.blockmotion}-klossene.
 
   ```blocks
   når grønt flagg klikkes
-  for alltid
+  gjenta for alltid
       gå til [musepeker v]
   slutt
   ```
@@ -74,7 +74,7 @@ interessert i nå er `penn på`{.blockpen} og `penn av`{.blockpen}.
 
   ```blocks
   når grønt flagg klikkes
-  for alltid
+  gjenta for alltid
       gå til [musepeker v]
       hvis <museknappen er trykket?>
           penn på
@@ -101,7 +101,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   slett
-  for alltid
+  gjenta for alltid
       gå til [musepeker v]
       hvis <museknappen er trykket?>
           penn på
@@ -248,7 +248,7 @@ musepekeren er utenfor tavlas `x`- og `y`-koordinater, så virker ikke blyanten.
   ```blocks
   når grønt flagg klikkes
   slett
-  for alltid
+  gjenta for alltid
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
           hvis <museknappen er trykket?>
@@ -270,7 +270,7 @@ musepekeren er utenfor tavlas `x`- og `y`-koordinater, så virker ikke blyanten.
   ```blocks
   når grønt flagg klikkes
   slett
-  for alltid
+  gjenta for alltid
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
           vis
@@ -404,7 +404,7 @@ __Klikk på det grønne flagget.__
   ```blocks
   når grønt flagg klikkes
   slett
-  for alltid
+  gjenta for alltid
       hvis <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeker v]
           vis

--- a/src/scratch/tegneprogram/tegneprogram_nn.md
+++ b/src/scratch/tegneprogram/tegneprogram_nn.md
@@ -53,12 +53,12 @@ Den fyrste delen kan du gjerne få hjelp av ein voksen til å gjere!
 
   ![Bilete av ein blyant med flytta senterpunkt](senterpunkt.png)
 
-- [ ] Få blyanten til å følgje musepeikaren rundt på scena ved å bruke `for
-  alltid`{.blockcontrol}- og `gå til musepeikar`{.blockmotion}-klossane.
+- [ ] Få blyanten til å følgje musepeikaren rundt på scena ved å bruke `gjenta
+  for alltid`{.blockcontrol}- og `gå til musepeikar`{.blockmotion}-klossane.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå til [musepeikar v]
   slutt
   ```
@@ -74,7 +74,7 @@ interesserte i no er `penn ned`{.blockpen} og `penn opp`{.blockpen}.
 
   ```blocks
   når @greenFlag vert trykt på
-  for alltid
+  gjenta for alltid
       gå til [musepeikar v]
       viss <museknappen er trykt?>
           penn ned
@@ -101,7 +101,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   slett
-  for alltid
+  gjenta for alltid
       gå til [musepeikar v]
       viss <museknappen er trykt?>
           penn ned
@@ -249,7 +249,7 @@ blyanten.
   ```blocks
   når @greenFlag vert trykt på
   slett
-  for alltid
+  gjenta for alltid
       viss <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeikar v]
           viss <museknappen er trykt?>
@@ -271,7 +271,7 @@ blyanten.
   ```blocks
   når @greenFlag vert trykt på
   slett
-  for alltid
+  gjenta for alltid
       viss <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeikar v]
           vis
@@ -405,7 +405,7 @@ __Klikk på det grøne flagget.__
   ```blocks
   når @greenFlag vert trykt på
   slett
-  for alltid
+  gjenta for alltid
       viss <<<(mus x) > [-230]> og <(mus x) < [230]>> og <<(mus y) > [-120]> og <(mus y) < [170]>>>
           gå til [musepeikar v]
           vis

--- a/src/scratch/veiledning_kom_i_gang/kom_i_gang_med_scratch.md
+++ b/src/scratch/veiledning_kom_i_gang/kom_i_gang_med_scratch.md
@@ -212,11 +212,11 @@ Alternativt, kan du også jobbe gjennom første steg i oppgaven sammen med barna
   flinke til å gjøre ting mange ganger. Dette programmerer vi ved hjelp av noe
   som heter løkker.
 
-  Klikk på `Styring`{.blockcontrol}-kategorien, og dra ut en `for
+  Klikk på `Styring`{.blockcontrol}-kategorien, og dra ut en `gjenta for
   alltid`{.b}-kloss slik at den legger seg rundt skriptet ditt.
 
   ```blocks
-  for alltid
+  gjenta for alltid
       endre [farge v] effekt med (25)
       gå (20) steg
       pek mot [musepeker v]
@@ -251,4 +251,3 @@ På alle sider - oppgaver og veiledninger - er det en `Rapporter et
 problem`-knapp nederst som du kan trykke for å sende oss en tilbakemelding. Bruk
 denne! Vi er veldig takknemlige for alle forslag som kan gjøre disse sidene enda
 nyttigere!
-

--- a/src/scratch/veiledning_kom_i_gang/kom_i_gang_med_scratch_nn.md
+++ b/src/scratch/veiledning_kom_i_gang/kom_i_gang_med_scratch_nn.md
@@ -214,11 +214,11 @@ Alternativt kan du jobbe gjennom fyrste steg i oppgåva saman med borna.
   til å gjere ting mange gonger. Dette programmerer me ved hjelp av noko som
   heiter løkker.
 
-  Klikk på `Styring`{.blockcontrol}-kategorien, og dra ut ein `for
+  Klikk på `Styring`{.blockcontrol}-kategorien, og dra ut ein `gjenta for
   alltid`{.b}-kloss slik at den legg seg rundt skriptet ditt.
 
   ```blocks
-  for alltid
+  gjenta for alltid
       endre [farge v] effekt med (25)
       gå (20) steg
       pek mot [musepeker v]


### PR DESCRIPTION
Og dessuten var det noen problemer i orkenlop:
- Løvinnen er borte, vi må bruke en løve
- Bakgrunnen desert er ikke i utendørs eller natur-kategori lenger, den finnes bare i "alle"
- Kategorien "ting" finnes ikke lenger, så knappen "Button3" må finnes i "Alle".

Jeg har også feilmeldt de to siste punktene på scratch.mit.edu på forumet deres.

Egentlig trenger orkenlop en litt bedre gjennomgang fordi piksel posisjonene passer ikke særlig bra for løven med lang hale o.l. men jeg har ikke mulighet til å gjennomteste den nå.
