### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '10'
       - name: Clone codeclub-viewer


### PR DESCRIPTION
Hi,
Updated two github actions to newer version to fixes warning when action is run
![image](https://github.com/kodeklubben/oppgaver/assets/9848846/56b0e6f4-2dd8-4703-a968-ba4f59d9cd2f)

See any action runs for the warning:
https://github.com/kodeklubben/oppgaver/actions/runs/4870480294