### PR TITLE
fix flappy_bird.md

### DIFF
--- a/src/microbit/pxt_flappy_bird/flappy_bird.md
+++ b/src/microbit/pxt_flappy_bird/flappy_bird.md
@@ -243,8 +243,10 @@ basic.forever(function () {
                 game.gameOver()
             }
         }
+        if (hinder.get(LedSpriteProperty.X) == 0){
         game.addScore(1)
         hinder.delete()
+        }
     }
 })
 ```


### PR DESCRIPTION
koden deres sletter hinder og oppdaterer score hele tiden, jeg endra den til å bare gjøre det når hinderet sin x-koordinat er 0 altså når den er helt på kanten av skjermen.